### PR TITLE
Add source code string for emojis

### DIFF
--- a/charConverter.js
+++ b/charConverter.js
@@ -1,0 +1,183 @@
+// Script to convert a JSON file with "character" emojis to a JSON file with "source code" emojis
+// This was probably a one-time thing but I'll commit the code in case it is useful in the future.
+//
+// Usage: `node charConverter.js`
+
+const fs = require('fs');
+const path = './src/main/resources/emojis.json';
+const path2 = './src/main/resources/emojis2.json';
+const f = fs.readFileSync(path, 'utf8');
+const json = JSON.parse(f);
+
+const newJson = json.reduce((acc, e) => {
+  acc.push({
+    emojiChar: e.emoji,
+    emoji: convertCharStr2jEsc(e.emoji, ''),
+    description: e.description,
+    supports_fitzpatrick: e.supports_fitzpatrick || undefined,
+    aliases: e.aliases,
+    tags: e.tags,
+  });
+  return acc;
+}, []);
+
+const newFile = JSON.stringify(newJson, (key, value) => value, 2);
+fs.writeFileSync(path2, newFile);
+
+
+
+///////////////////////////////////////////////////////////////////
+// Following functions copied from https://github.com/r12a/app-conversion/blob/gh-pages/conversionfunctions.js
+// http://rishida.net/
+///////////////////////////////////////////////////////////////////
+
+
+
+function convertCharStr2jEsc(str, parameters) {
+  // Converts a string of characters to JavaScript escapes
+  // str: sequence of Unicode characters
+  // parameters: a semicolon separated string showing ids for checkboxes that are turned on
+  var highsurrogate = 0;
+  var suppCP;
+  var pad;
+  var n = 0;
+  var pars = parameters.split(';');
+  var outputString = '';
+  for (var i = 0; i < str.length; i++) {
+    var cc = str.charCodeAt(i);
+    if (cc < 0 || cc > 0xffff) {
+      outputString +=
+        '!Error in convertCharStr2UTF16: unexpected charCodeAt result, cc=' +
+        cc +
+        '!';
+    }
+    if (highsurrogate != 0) {
+      // this is a supp char, and cc contains the low surrogate
+      if (0xdc00 <= cc && cc <= 0xdfff) {
+        suppCP = 0x10000 + ((highsurrogate - 0xd800) << 10) + (cc - 0xdc00);
+        if (parameters.match(/cstyleSC/)) {
+          pad = suppCP.toString(16);
+          while (pad.length < 8) {
+            pad = '0' + pad;
+          }
+          outputString += '\\U' + pad;
+        } else if (parameters.match(/es6styleSC/)) {
+          pad = suppCP.toString(16).toUpperCase();
+          outputString += '\\u{' + pad + '}';
+        } else {
+          suppCP -= 0x10000;
+          outputString +=
+            '\\u' +
+            dec2hex4(0xd800 | (suppCP >> 10)) +
+            '\\u' +
+            dec2hex4(0xdc00 | (suppCP & 0x3ff));
+        }
+        highsurrogate = 0;
+        continue;
+      } else {
+        outputString +=
+          'Error in convertCharStr2UTF16: low surrogate expected, cc=' +
+          cc +
+          '!';
+        highsurrogate = 0;
+      }
+    }
+    if (0xd800 <= cc && cc <= 0xdbff) {
+      // start of supplementary character
+      highsurrogate = cc;
+    } else {
+      // this is a BMP character
+      //outputString += dec2hex(cc) + ' ';
+      switch (cc) {
+        case 0:
+          outputString += '\\0';
+          break;
+        case 8:
+          outputString += '\\b';
+          break;
+        case 9:
+          if (parameters.match(/noCR/)) {
+            outputString += '\\t';
+          } else {
+            outputString += '\t';
+          }
+          break;
+        case 10:
+          if (parameters.match(/noCR/)) {
+            outputString += '\\n';
+          } else {
+            outputString += '\n';
+          }
+          break;
+        case 13:
+          if (parameters.match(/noCR/)) {
+            outputString += '\\r';
+          } else {
+            outputString += '\r';
+          }
+          break;
+        case 11:
+          outputString += '\\v';
+          break;
+        case 12:
+          outputString += '\\f';
+          break;
+        case 34:
+          if (parameters.match(/noCR/)) {
+            outputString += '\\"';
+          } else {
+            outputString += '"';
+          }
+          break;
+        case 39:
+          if (parameters.match(/noCR/)) {
+            outputString += "\\'";
+          } else {
+            outputString += "'";
+          }
+          break;
+        case 92:
+          outputString += '\\\\';
+          break;
+        default:
+          if (cc > 0x1f && cc < 0x7f) {
+            outputString += String.fromCharCode(cc);
+          } else {
+            pad = cc.toString(16).toUpperCase();
+            while (pad.length < 4) {
+              pad = '0' + pad;
+            }
+            outputString += '\\u' + pad;
+          }
+      }
+    }
+  }
+  return outputString;
+}
+
+function dec2hex4(textString) {
+  var hexequiv = new Array(
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F'
+  );
+  return (
+    hexequiv[(textString >> 12) & 0xf] +
+    hexequiv[(textString >> 8) & 0xf] +
+    hexequiv[(textString >> 4) & 0xf] +
+    hexequiv[textString & 0xf]
+  );
+}

--- a/src/main/resources/emojis.json
+++ b/src/main/resources/emojis.json
@@ -1,6 +1,7 @@
 [
   {
-    "emoji": "😄",
+    "emojiChar": "😄",
+    "emoji": "\uD83D\uDE04",
     "description": "smiling face with open mouth and smiling eyes",
     "aliases": [
       "smile"
@@ -12,7 +13,8 @@
     ]
   },
   {
-    "emoji": "😃",
+    "emojiChar": "😃",
+    "emoji": "\uD83D\uDE03",
     "description": "smiling face with open mouth",
     "aliases": [
       "smiley"
@@ -24,7 +26,8 @@
     ]
   },
   {
-    "emoji": "😀",
+    "emojiChar": "😀",
+    "emoji": "\uD83D\uDE00",
     "description": "grinning face",
     "aliases": [
       "grinning"
@@ -35,7 +38,8 @@
     ]
   },
   {
-    "emoji": "😊",
+    "emojiChar": "😊",
+    "emoji": "\uD83D\uDE0A",
     "description": "smiling face with smiling eyes",
     "aliases": [
       "blush"
@@ -45,7 +49,8 @@
     ]
   },
   {
-    "emoji": "☺",
+    "emojiChar": "☺",
+    "emoji": "\u263A",
     "description": "white smiling face",
     "aliases": [
       "relaxed"
@@ -56,7 +61,8 @@
     ]
   },
   {
-    "emoji": "😉",
+    "emojiChar": "😉",
+    "emoji": "\uD83D\uDE09",
     "description": "winking face",
     "aliases": [
       "wink"
@@ -66,7 +72,8 @@
     ]
   },
   {
-    "emoji": "😍",
+    "emojiChar": "😍",
+    "emoji": "\uD83D\uDE0D",
     "description": "smiling face with heart-shaped eyes",
     "aliases": [
       "heart_eyes"
@@ -77,7 +84,8 @@
     ]
   },
   {
-    "emoji": "😘",
+    "emojiChar": "😘",
+    "emoji": "\uD83D\uDE18",
     "description": "face throwing a kiss",
     "aliases": [
       "kissing_heart"
@@ -87,34 +95,35 @@
     ]
   },
   {
-    "emoji": "😚",
+    "emojiChar": "😚",
+    "emoji": "\uD83D\uDE1A",
     "description": "kissing face with closed eyes",
     "aliases": [
       "kissing_closed_eyes"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😗",
+    "emojiChar": "😗",
+    "emoji": "\uD83D\uDE17",
     "description": "kissing face",
     "aliases": [
       "kissing"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😙",
+    "emojiChar": "😙",
+    "emoji": "\uD83D\uDE19",
     "description": "kissing face with smiling eyes",
     "aliases": [
       "kissing_smiling_eyes"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😜",
+    "emojiChar": "😜",
+    "emoji": "\uD83D\uDE1C",
     "description": "face with stuck-out tongue and winking eye",
     "aliases": [
       "stuck_out_tongue_winking_eye"
@@ -125,7 +134,8 @@
     ]
   },
   {
-    "emoji": "😝",
+    "emojiChar": "😝",
+    "emoji": "\uD83D\uDE1D",
     "description": "face with stuck-out tongue and tightly-closed eyes",
     "aliases": [
       "stuck_out_tongue_closed_eyes"
@@ -135,43 +145,44 @@
     ]
   },
   {
-    "emoji": "😛",
+    "emojiChar": "😛",
+    "emoji": "\uD83D\uDE1B",
     "description": "face with stuck-out tongue",
     "aliases": [
       "stuck_out_tongue"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😳",
+    "emojiChar": "😳",
+    "emoji": "\uD83D\uDE33",
     "description": "flushed face",
     "aliases": [
       "flushed"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😁",
+    "emojiChar": "😁",
+    "emoji": "\uD83D\uDE01",
     "description": "grinning face with smiling eyes",
     "aliases": [
       "grin"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😔",
+    "emojiChar": "😔",
+    "emoji": "\uD83D\uDE14",
     "description": "pensive face",
     "aliases": [
       "pensive"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😌",
+    "emojiChar": "😌",
+    "emoji": "\uD83D\uDE0C",
     "description": "relieved face",
     "aliases": [
       "relieved"
@@ -181,7 +192,8 @@
     ]
   },
   {
-    "emoji": "😒",
+    "emojiChar": "😒",
+    "emoji": "\uD83D\uDE12",
     "description": "unamused face",
     "aliases": [
       "unamused"
@@ -191,7 +203,8 @@
     ]
   },
   {
-    "emoji": "😞",
+    "emojiChar": "😞",
+    "emoji": "\uD83D\uDE1E",
     "description": "disappointed face",
     "aliases": [
       "disappointed"
@@ -201,7 +214,8 @@
     ]
   },
   {
-    "emoji": "😣",
+    "emojiChar": "😣",
+    "emoji": "\uD83D\uDE23",
     "description": "persevering face",
     "aliases": [
       "persevere"
@@ -211,7 +225,8 @@
     ]
   },
   {
-    "emoji": "😢",
+    "emojiChar": "😢",
+    "emoji": "\uD83D\uDE22",
     "description": "crying face",
     "aliases": [
       "cry"
@@ -222,7 +237,8 @@
     ]
   },
   {
-    "emoji": "😂",
+    "emojiChar": "😂",
+    "emoji": "\uD83D\uDE02",
     "description": "face with tears of joy",
     "aliases": [
       "joy"
@@ -232,7 +248,8 @@
     ]
   },
   {
-    "emoji": "😭",
+    "emojiChar": "😭",
+    "emoji": "\uD83D\uDE2D",
     "description": "loudly crying face",
     "aliases": [
       "sob"
@@ -244,7 +261,8 @@
     ]
   },
   {
-    "emoji": "😪",
+    "emojiChar": "😪",
+    "emoji": "\uD83D\uDE2A",
     "description": "sleepy face",
     "aliases": [
       "sleepy"
@@ -254,7 +272,8 @@
     ]
   },
   {
-    "emoji": "😥",
+    "emojiChar": "😥",
+    "emoji": "\uD83D\uDE25",
     "description": "disappointed but relieved face",
     "aliases": [
       "disappointed_relieved"
@@ -266,7 +285,8 @@
     ]
   },
   {
-    "emoji": "😰",
+    "emojiChar": "😰",
+    "emoji": "\uD83D\uDE30",
     "description": "face with open mouth and cold sweat",
     "aliases": [
       "cold_sweat"
@@ -276,7 +296,8 @@
     ]
   },
   {
-    "emoji": "😅",
+    "emojiChar": "😅",
+    "emoji": "\uD83D\uDE05",
     "description": "smiling face with open mouth and cold sweat",
     "aliases": [
       "sweat_smile"
@@ -286,16 +307,17 @@
     ]
   },
   {
-    "emoji": "😓",
+    "emojiChar": "😓",
+    "emoji": "\uD83D\uDE13",
     "description": "face with cold sweat",
     "aliases": [
       "sweat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😩",
+    "emojiChar": "😩",
+    "emoji": "\uD83D\uDE29",
     "description": "weary face",
     "aliases": [
       "weary"
@@ -305,7 +327,8 @@
     ]
   },
   {
-    "emoji": "😫",
+    "emojiChar": "😫",
+    "emoji": "\uD83D\uDE2B",
     "description": "tired face",
     "aliases": [
       "tired_face"
@@ -316,7 +339,8 @@
     ]
   },
   {
-    "emoji": "😨",
+    "emojiChar": "😨",
+    "emoji": "\uD83D\uDE28",
     "description": "fearful face",
     "aliases": [
       "fearful"
@@ -328,7 +352,8 @@
     ]
   },
   {
-    "emoji": "😱",
+    "emojiChar": "😱",
+    "emoji": "\uD83D\uDE31",
     "description": "face screaming in fear",
     "aliases": [
       "scream"
@@ -339,7 +364,8 @@
     ]
   },
   {
-    "emoji": "😠",
+    "emojiChar": "😠",
+    "emoji": "\uD83D\uDE20",
     "description": "angry face",
     "aliases": [
       "angry"
@@ -350,7 +376,8 @@
     ]
   },
   {
-    "emoji": "😡",
+    "emojiChar": "😡",
+    "emoji": "\uD83D\uDE21",
     "description": "pouting face",
     "aliases": [
       "rage"
@@ -360,7 +387,8 @@
     ]
   },
   {
-    "emoji": "😤",
+    "emojiChar": "😤",
+    "emoji": "\uD83D\uDE24",
     "description": "face with look of triumph",
     "aliases": [
       "triumph"
@@ -370,16 +398,17 @@
     ]
   },
   {
-    "emoji": "😖",
+    "emojiChar": "😖",
+    "emoji": "\uD83D\uDE16",
     "description": "confounded face",
     "aliases": [
       "confounded"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😆",
+    "emojiChar": "😆",
+    "emoji": "\uD83D\uDE06",
     "description": "smiling face with open mouth and tightly-closed eyes",
     "aliases": [
       "laughing",
@@ -391,7 +420,8 @@
     ]
   },
   {
-    "emoji": "😋",
+    "emojiChar": "😋",
+    "emoji": "\uD83D\uDE0B",
     "description": "face savouring delicious food",
     "aliases": [
       "yum"
@@ -402,7 +432,8 @@
     ]
   },
   {
-    "emoji": "😷",
+    "emojiChar": "😷",
+    "emoji": "\uD83D\uDE37",
     "description": "face with medical mask",
     "aliases": [
       "mask"
@@ -413,7 +444,8 @@
     ]
   },
   {
-    "emoji": "😎",
+    "emojiChar": "😎",
+    "emoji": "\uD83D\uDE0E",
     "description": "smiling face with sunglasses",
     "aliases": [
       "sunglasses"
@@ -423,7 +455,8 @@
     ]
   },
   {
-    "emoji": "😴",
+    "emojiChar": "😴",
+    "emoji": "\uD83D\uDE34",
     "description": "sleeping face",
     "aliases": [
       "sleeping"
@@ -433,16 +466,17 @@
     ]
   },
   {
-    "emoji": "😵",
+    "emojiChar": "😵",
+    "emoji": "\uD83D\uDE35",
     "description": "dizzy face",
     "aliases": [
       "dizzy_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😲",
+    "emojiChar": "😲",
+    "emoji": "\uD83D\uDE32",
     "description": "astonished face",
     "aliases": [
       "astonished"
@@ -453,7 +487,8 @@
     ]
   },
   {
-    "emoji": "😟",
+    "emojiChar": "😟",
+    "emoji": "\uD83D\uDE1F",
     "description": "worried face",
     "aliases": [
       "worried"
@@ -463,16 +498,17 @@
     ]
   },
   {
-    "emoji": "😦",
+    "emojiChar": "😦",
+    "emoji": "\uD83D\uDE26",
     "description": "frowning face with open mouth",
     "aliases": [
       "frowning"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😧",
+    "emojiChar": "😧",
+    "emoji": "\uD83D\uDE27",
     "description": "anguished face",
     "aliases": [
       "anguished"
@@ -482,7 +518,8 @@
     ]
   },
   {
-    "emoji": "😈",
+    "emojiChar": "😈",
+    "emoji": "\uD83D\uDE08",
     "description": "smiling face with horns",
     "aliases": [
       "smiling_imp"
@@ -494,7 +531,8 @@
     ]
   },
   {
-    "emoji": "👿",
+    "emojiChar": "👿",
+    "emoji": "\uD83D\uDC7F",
     "description": "imp",
     "aliases": [
       "imp"
@@ -507,7 +545,8 @@
     ]
   },
   {
-    "emoji": "😮",
+    "emojiChar": "😮",
+    "emoji": "\uD83D\uDE2E",
     "description": "face with open mouth",
     "aliases": [
       "open_mouth"
@@ -519,16 +558,17 @@
     ]
   },
   {
-    "emoji": "😬",
+    "emojiChar": "😬",
+    "emoji": "\uD83D\uDE2C",
     "description": "grimacing face",
     "aliases": [
       "grimacing"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😐",
+    "emojiChar": "😐",
+    "emoji": "\uD83D\uDE10",
     "description": "neutral face",
     "aliases": [
       "neutral_face"
@@ -538,16 +578,17 @@
     ]
   },
   {
-    "emoji": "😕",
+    "emojiChar": "😕",
+    "emoji": "\uD83D\uDE15",
     "description": "confused face",
     "aliases": [
       "confused"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😯",
+    "emojiChar": "😯",
+    "emoji": "\uD83D\uDE2F",
     "description": "hushed face",
     "aliases": [
       "hushed"
@@ -558,7 +599,8 @@
     ]
   },
   {
-    "emoji": "😶",
+    "emojiChar": "😶",
+    "emoji": "\uD83D\uDE36",
     "description": "face without mouth",
     "aliases": [
       "no_mouth"
@@ -569,7 +611,8 @@
     ]
   },
   {
-    "emoji": "😇",
+    "emojiChar": "😇",
+    "emoji": "\uD83D\uDE07",
     "description": "smiling face with halo",
     "aliases": [
       "innocent"
@@ -579,7 +622,8 @@
     ]
   },
   {
-    "emoji": "😏",
+    "emojiChar": "😏",
+    "emoji": "\uD83D\uDE0F",
     "description": "smirking face",
     "aliases": [
       "smirk"
@@ -589,36 +633,37 @@
     ]
   },
   {
-    "emoji": "😑",
+    "emojiChar": "😑",
+    "emoji": "\uD83D\uDE11",
     "description": "expressionless face",
     "aliases": [
       "expressionless"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👲",
+    "emojiChar": "👲",
+    "emoji": "\uD83D\uDC72",
     "description": "man with gua pi mao",
     "supports_fitzpatrick": true,
     "aliases": [
       "man_with_gua_pi_mao"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👳",
+    "emojiChar": "👳",
+    "emoji": "\uD83D\uDC73",
     "description": "man with turban",
     "supports_fitzpatrick": true,
     "aliases": [
       "man_with_turban"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👮",
+    "emojiChar": "👮",
+    "emoji": "\uD83D\uDC6E",
     "description": "police officer",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -630,7 +675,8 @@
     ]
   },
   {
-    "emoji": "👷",
+    "emojiChar": "👷",
+    "emoji": "\uD83D\uDC77",
     "description": "construction worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -641,17 +687,18 @@
     ]
   },
   {
-    "emoji": "💂",
+    "emojiChar": "💂",
+    "emoji": "\uD83D\uDC82",
     "description": "guardsman",
     "supports_fitzpatrick": true,
     "aliases": [
       "guardsman"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👶",
+    "emojiChar": "👶",
+    "emoji": "\uD83D\uDC76",
     "description": "baby",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -663,7 +710,8 @@
     ]
   },
   {
-    "emoji": "👦",
+    "emojiChar": "👦",
+    "emoji": "\uD83D\uDC66",
     "description": "boy",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -674,7 +722,8 @@
     ]
   },
   {
-    "emoji": "👧",
+    "emojiChar": "👧",
+    "emoji": "\uD83D\uDC67",
     "description": "girl",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -685,7 +734,8 @@
     ]
   },
   {
-    "emoji": "👨",
+    "emojiChar": "👨",
+    "emoji": "\uD83D\uDC68",
     "description": "man",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -698,7 +748,8 @@
     ]
   },
   {
-    "emoji": "👩",
+    "emojiChar": "👩",
+    "emoji": "\uD83D\uDC69",
     "description": "woman",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -709,27 +760,28 @@
     ]
   },
   {
-    "emoji": "👴",
+    "emojiChar": "👴",
+    "emoji": "\uD83D\uDC74",
     "description": "older man",
     "supports_fitzpatrick": true,
     "aliases": [
       "older_man"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👵",
+    "emojiChar": "👵",
+    "emoji": "\uD83D\uDC75",
     "description": "older woman",
     "supports_fitzpatrick": true,
     "aliases": [
       "older_woman"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👱",
+    "emojiChar": "👱",
+    "emoji": "\uD83D\uDC71",
     "description": "person with blond hair",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -740,17 +792,18 @@
     ]
   },
   {
-    "emoji": "👼",
+    "emojiChar": "👼",
+    "emoji": "\uD83D\uDC7C",
     "description": "baby angel",
     "supports_fitzpatrick": true,
     "aliases": [
       "angel"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👸",
+    "emojiChar": "👸",
+    "emoji": "\uD83D\uDC78",
     "description": "princess",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -763,52 +816,53 @@
     ]
   },
   {
-    "emoji": "😺",
+    "emojiChar": "😺",
+    "emoji": "\uD83D\uDE3A",
     "description": "smiling cat face with open mouth",
     "aliases": [
       "smiley_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😸",
+    "emojiChar": "😸",
+    "emoji": "\uD83D\uDE38",
     "description": "grinning cat face with smiling eyes",
     "aliases": [
       "smile_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😻",
+    "emojiChar": "😻",
+    "emoji": "\uD83D\uDE3B",
     "description": "smiling cat face with heart-shaped eyes",
     "aliases": [
       "heart_eyes_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😽",
+    "emojiChar": "😽",
+    "emoji": "\uD83D\uDE3D",
     "description": "kissing cat face with closed eyes",
     "aliases": [
       "kissing_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😼",
+    "emojiChar": "😼",
+    "emoji": "\uD83D\uDE3C",
     "description": "cat face with wry smile",
     "aliases": [
       "smirk_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🙀",
+    "emojiChar": "🙀",
+    "emoji": "\uD83D\uDE40",
     "description": "weary cat face",
     "aliases": [
       "scream_cat"
@@ -818,7 +872,8 @@
     ]
   },
   {
-    "emoji": "😿",
+    "emojiChar": "😿",
+    "emoji": "\uD83D\uDE3F",
     "description": "crying cat face",
     "aliases": [
       "crying_cat_face"
@@ -829,25 +884,26 @@
     ]
   },
   {
-    "emoji": "😹",
+    "emojiChar": "😹",
+    "emoji": "\uD83D\uDE39",
     "description": "cat face with tears of joy",
     "aliases": [
       "joy_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "😾",
+    "emojiChar": "😾",
+    "emoji": "\uD83D\uDE3E",
     "description": "pouting cat face",
     "aliases": [
       "pouting_cat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👹",
+    "emojiChar": "👹",
+    "emoji": "\uD83D\uDC79",
     "description": "japanese ogre",
     "aliases": [
       "japanese_ogre"
@@ -857,16 +913,17 @@
     ]
   },
   {
-    "emoji": "👺",
+    "emojiChar": "👺",
+    "emoji": "\uD83D\uDC7A",
     "description": "japanese goblin",
     "aliases": [
       "japanese_goblin"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🙈",
+    "emojiChar": "🙈",
+    "emoji": "\uD83D\uDE48",
     "description": "see-no-evil monkey",
     "aliases": [
       "see_no_evil"
@@ -878,7 +935,8 @@
     ]
   },
   {
-    "emoji": "🙉",
+    "emojiChar": "🙉",
+    "emoji": "\uD83D\uDE49",
     "description": "hear-no-evil monkey",
     "aliases": [
       "hear_no_evil"
@@ -889,7 +947,8 @@
     ]
   },
   {
-    "emoji": "🙊",
+    "emojiChar": "🙊",
+    "emoji": "\uD83D\uDE4A",
     "description": "speak-no-evil monkey",
     "aliases": [
       "speak_no_evil"
@@ -901,7 +960,8 @@
     ]
   },
   {
-    "emoji": "💀",
+    "emojiChar": "💀",
+    "emoji": "\uD83D\uDC80",
     "description": "skull",
     "aliases": [
       "skull"
@@ -913,7 +973,8 @@
     ]
   },
   {
-    "emoji": "👽",
+    "emojiChar": "👽",
+    "emoji": "\uD83D\uDC7D",
     "description": "extraterrestrial alien",
     "aliases": [
       "alien"
@@ -923,7 +984,8 @@
     ]
   },
   {
-    "emoji": "💩",
+    "emojiChar": "💩",
+    "emoji": "\uD83D\uDCA9",
     "description": "pile of poo",
     "aliases": [
       "hankey",
@@ -935,7 +997,8 @@
     ]
   },
   {
-    "emoji": "🔥",
+    "emojiChar": "🔥",
+    "emoji": "\uD83D\uDD25",
     "description": "fire",
     "aliases": [
       "fire"
@@ -945,7 +1008,8 @@
     ]
   },
   {
-    "emoji": "✨",
+    "emojiChar": "✨",
+    "emoji": "\u2728",
     "description": "sparkles",
     "aliases": [
       "sparkles"
@@ -955,16 +1019,17 @@
     ]
   },
   {
-    "emoji": "🌟",
+    "emojiChar": "🌟",
+    "emoji": "\uD83C\uDF1F",
     "description": "glowing star",
     "aliases": [
       "star2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💫",
+    "emojiChar": "💫",
+    "emoji": "\uD83D\uDCAB",
     "description": "dizzy symbol",
     "aliases": [
       "dizzy"
@@ -974,7 +1039,8 @@
     ]
   },
   {
-    "emoji": "💥",
+    "emojiChar": "💥",
+    "emoji": "\uD83D\uDCA5",
     "description": "collision symbol",
     "aliases": [
       "boom",
@@ -985,7 +1051,8 @@
     ]
   },
   {
-    "emoji": "💢",
+    "emojiChar": "💢",
+    "emoji": "\uD83D\uDCA2",
     "description": "anger symbol",
     "aliases": [
       "anger"
@@ -995,7 +1062,8 @@
     ]
   },
   {
-    "emoji": "💦",
+    "emojiChar": "💦",
+    "emoji": "\uD83D\uDCA6",
     "description": "splashing sweat symbol",
     "aliases": [
       "sweat_drops"
@@ -1006,7 +1074,8 @@
     ]
   },
   {
-    "emoji": "💧",
+    "emojiChar": "💧",
+    "emoji": "\uD83D\uDCA7",
     "description": "droplet",
     "aliases": [
       "droplet"
@@ -1016,7 +1085,8 @@
     ]
   },
   {
-    "emoji": "💤",
+    "emojiChar": "💤",
+    "emoji": "\uD83D\uDCA4",
     "description": "sleeping symbol",
     "aliases": [
       "zzz"
@@ -1026,7 +1096,8 @@
     ]
   },
   {
-    "emoji": "💨",
+    "emojiChar": "💨",
+    "emoji": "\uD83D\uDCA8",
     "description": "dash symbol",
     "aliases": [
       "dash"
@@ -1038,7 +1109,8 @@
     ]
   },
   {
-    "emoji": "👂",
+    "emojiChar": "👂",
+    "emoji": "\uD83D\uDC42",
     "description": "ear",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1051,7 +1123,8 @@
     ]
   },
   {
-    "emoji": "👀",
+    "emojiChar": "👀",
+    "emoji": "\uD83D\uDC40",
     "description": "eyes",
     "aliases": [
       "eyes"
@@ -1063,7 +1136,8 @@
     ]
   },
   {
-    "emoji": "👃",
+    "emojiChar": "👃",
+    "emoji": "\uD83D\uDC43",
     "description": "nose",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1074,7 +1148,8 @@
     ]
   },
   {
-    "emoji": "👅",
+    "emojiChar": "👅",
+    "emoji": "\uD83D\uDC45",
     "description": "tongue",
     "aliases": [
       "tongue"
@@ -1084,7 +1159,8 @@
     ]
   },
   {
-    "emoji": "👄",
+    "emojiChar": "👄",
+    "emoji": "\uD83D\uDC44",
     "description": "mouth",
     "aliases": [
       "lips"
@@ -1094,7 +1170,8 @@
     ]
   },
   {
-    "emoji": "👍",
+    "emojiChar": "👍",
+    "emoji": "\uD83D\uDC4D",
     "description": "thumbs up sign",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1107,7 +1184,8 @@
     ]
   },
   {
-    "emoji": "👎",
+    "emojiChar": "👎",
+    "emoji": "\uD83D\uDC4E",
     "description": "thumbs down sign",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1120,17 +1198,18 @@
     ]
   },
   {
-    "emoji": "👌",
+    "emojiChar": "👌",
+    "emoji": "\uD83D\uDC4C",
     "description": "ok hand sign",
     "supports_fitzpatrick": true,
     "aliases": [
       "ok_hand"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👊",
+    "emojiChar": "👊",
+    "emoji": "\uD83D\uDC4A",
     "description": "fisted hand sign",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1142,7 +1221,8 @@
     ]
   },
   {
-    "emoji": "✊",
+    "emojiChar": "✊",
+    "emoji": "\u270A",
     "description": "raised fist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1153,7 +1233,8 @@
     ]
   },
   {
-    "emoji": "✌",
+    "emojiChar": "✌",
+    "emoji": "\u270C",
     "description": "victory hand",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1165,7 +1246,8 @@
     ]
   },
   {
-    "emoji": "👋",
+    "emojiChar": "👋",
+    "emoji": "\uD83D\uDC4B",
     "description": "waving hand sign",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1176,7 +1258,8 @@
     ]
   },
   {
-    "emoji": "✋",
+    "emojiChar": "✋",
+    "emoji": "\u270B",
     "description": "raised hand",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1189,57 +1272,58 @@
     ]
   },
   {
-    "emoji": "👐",
+    "emojiChar": "👐",
+    "emoji": "\uD83D\uDC50",
     "description": "open hands sign",
     "supports_fitzpatrick": true,
     "aliases": [
       "open_hands"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👆",
+    "emojiChar": "👆",
+    "emoji": "\uD83D\uDC46",
     "description": "white up pointing backhand index",
     "supports_fitzpatrick": true,
     "aliases": [
       "point_up_2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👇",
+    "emojiChar": "👇",
+    "emoji": "\uD83D\uDC47",
     "description": "white down pointing backhand index",
     "supports_fitzpatrick": true,
     "aliases": [
       "point_down"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👉",
+    "emojiChar": "👉",
+    "emoji": "\uD83D\uDC49",
     "description": "white right pointing backhand index",
     "supports_fitzpatrick": true,
     "aliases": [
       "point_right"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👈",
+    "emojiChar": "👈",
+    "emoji": "\uD83D\uDC48",
     "description": "white left pointing backhand index",
     "supports_fitzpatrick": true,
     "aliases": [
       "point_left"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🙌",
+    "emojiChar": "🙌",
+    "emoji": "\uD83D\uDE4C",
     "description": "person raising both hands in celebration",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1250,7 +1334,8 @@
     ]
   },
   {
-    "emoji": "🙏",
+    "emojiChar": "🙏",
+    "emoji": "\uD83D\uDE4F",
     "description": "person with folded hands",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1263,17 +1348,18 @@
     ]
   },
   {
-    "emoji": "☝",
+    "emojiChar": "☝",
+    "emoji": "\u261D",
     "description": "white up pointing index",
     "supports_fitzpatrick": true,
     "aliases": [
       "point_up"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👏",
+    "emojiChar": "👏",
+    "emoji": "\uD83D\uDC4F",
     "description": "clapping hands sign",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1285,7 +1371,8 @@
     ]
   },
   {
-    "emoji": "💪",
+    "emojiChar": "💪",
+    "emoji": "\uD83D\uDCAA",
     "description": "flexed biceps",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1299,17 +1386,18 @@
     ]
   },
   {
-    "emoji": "🚶",
+    "emojiChar": "🚶",
+    "emoji": "\uD83D\uDEB6",
     "description": "pedestrian",
     "supports_fitzpatrick": true,
     "aliases": [
       "walking"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏃",
+    "emojiChar": "🏃",
+    "emoji": "\uD83C\uDFC3",
     "description": "runner",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1323,7 +1411,8 @@
     ]
   },
   {
-    "emoji": "💃",
+    "emojiChar": "💃",
+    "emoji": "\uD83D\uDC83",
     "description": "dancer",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1334,7 +1423,8 @@
     ]
   },
   {
-    "emoji": "👫",
+    "emojiChar": "👫",
+    "emoji": "\uD83D\uDC6B",
     "description": "man and woman holding hands",
     "aliases": [
       "couple"
@@ -1344,7 +1434,8 @@
     ]
   },
   {
-    "emoji": "👪",
+    "emojiChar": "👪",
+    "emoji": "\uD83D\uDC6A",
     "description": "family",
     "aliases": [
       "family"
@@ -1356,7 +1447,8 @@
     ]
   },
   {
-    "emoji": "👬",
+    "emojiChar": "👬",
+    "emoji": "\uD83D\uDC6C",
     "description": "two men holding hands",
     "aliases": [
       "two_men_holding_hands"
@@ -1367,7 +1459,8 @@
     ]
   },
   {
-    "emoji": "👭",
+    "emojiChar": "👭",
+    "emoji": "\uD83D\uDC6D",
     "description": "two women holding hands",
     "aliases": [
       "two_women_holding_hands"
@@ -1378,25 +1471,26 @@
     ]
   },
   {
-    "emoji": "💏",
+    "emojiChar": "💏",
+    "emoji": "\uD83D\uDC8F",
     "description": "kiss",
     "aliases": [
       "couplekiss"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💑",
+    "emojiChar": "💑",
+    "emoji": "\uD83D\uDC91",
     "description": "couple with heart",
     "aliases": [
       "couple_with_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👯",
+    "emojiChar": "👯",
+    "emoji": "\uD83D\uDC6F",
     "description": "woman with bunny ears",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1407,17 +1501,18 @@
     ]
   },
   {
-    "emoji": "🙆",
+    "emojiChar": "🙆",
+    "emoji": "\uD83D\uDE46",
     "description": "face with ok gesture",
     "supports_fitzpatrick": true,
     "aliases": [
       "ok_woman"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🙅",
+    "emojiChar": "🙅",
+    "emoji": "\uD83D\uDE45",
     "description": "face with no good gesture",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1429,27 +1524,28 @@
     ]
   },
   {
-    "emoji": "💁",
+    "emojiChar": "💁",
+    "emoji": "\uD83D\uDC81",
     "description": "information desk person",
     "supports_fitzpatrick": true,
     "aliases": [
       "information_desk_person"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🙋",
+    "emojiChar": "🙋",
+    "emoji": "\uD83D\uDE4B",
     "description": "happy person raising one hand",
     "supports_fitzpatrick": true,
     "aliases": [
       "raising_hand"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💆",
+    "emojiChar": "💆",
+    "emoji": "\uD83D\uDC86",
     "description": "face massage",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1460,7 +1556,8 @@
     ]
   },
   {
-    "emoji": "💇",
+    "emojiChar": "💇",
+    "emoji": "\uD83D\uDC87",
     "description": "haircut",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1471,7 +1568,8 @@
     ]
   },
   {
-    "emoji": "💅",
+    "emojiChar": "💅",
+    "emoji": "\uD83D\uDC85",
     "description": "nail polish",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1483,7 +1581,8 @@
     ]
   },
   {
-    "emoji": "👰",
+    "emojiChar": "👰",
+    "emoji": "\uD83D\uDC70",
     "description": "bride with veil",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1495,17 +1594,18 @@
     ]
   },
   {
-    "emoji": "🙎",
+    "emojiChar": "🙎",
+    "emoji": "\uD83D\uDE4E",
     "description": "person with pouting face",
     "supports_fitzpatrick": true,
     "aliases": [
       "person_with_pouting_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🙍",
+    "emojiChar": "🙍",
+    "emoji": "\uD83D\uDE4D",
     "description": "person frowning",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1516,7 +1616,8 @@
     ]
   },
   {
-    "emoji": "🙇",
+    "emojiChar": "🙇",
+    "emoji": "\uD83D\uDE47",
     "description": "person bowing deeply",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1528,7 +1629,8 @@
     ]
   },
   {
-    "emoji": "🙇‍♀️",
+    "emojiChar": "🙇‍♀️",
+    "emoji": "\uD83D\uDE47\u200D\u2640\uFE0F",
     "description": "woman bowing deeply",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1541,7 +1643,8 @@
     ]
   },
   {
-    "emoji": "🙇‍♂️",
+    "emojiChar": "🙇‍♂️",
+    "emoji": "\uD83D\uDE47\u200D\u2642\uFE0F",
     "description": "man bowing deeply",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -1554,7 +1657,8 @@
     ]
   },
   {
-    "emoji": "🎩",
+    "emojiChar": "🎩",
+    "emoji": "\uD83C\uDFA9",
     "description": "top hat",
     "aliases": [
       "tophat"
@@ -1565,7 +1669,8 @@
     ]
   },
   {
-    "emoji": "👑",
+    "emojiChar": "👑",
+    "emoji": "\uD83D\uDC51",
     "description": "crown",
     "aliases": [
       "crown"
@@ -1577,16 +1682,17 @@
     ]
   },
   {
-    "emoji": "👒",
+    "emojiChar": "👒",
+    "emoji": "\uD83D\uDC52",
     "description": "womans hat",
     "aliases": [
       "womans_hat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👟",
+    "emojiChar": "👟",
+    "emoji": "\uD83D\uDC5F",
     "description": "athletic shoe",
     "aliases": [
       "athletic_shoe"
@@ -1598,17 +1704,18 @@
     ]
   },
   {
-    "emoji": "👞",
+    "emojiChar": "👞",
+    "emoji": "\uD83D\uDC5E",
     "description": "mans shoe",
     "aliases": [
       "mans_shoe",
       "shoe"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👡",
+    "emojiChar": "👡",
+    "emoji": "\uD83D\uDC61",
     "description": "womans sandal",
     "aliases": [
       "sandal"
@@ -1618,7 +1725,8 @@
     ]
   },
   {
-    "emoji": "👠",
+    "emojiChar": "👠",
+    "emoji": "\uD83D\uDC60",
     "description": "high-heeled shoe",
     "aliases": [
       "high_heel"
@@ -1628,26 +1736,27 @@
     ]
   },
   {
-    "emoji": "👢",
+    "emojiChar": "👢",
+    "emoji": "\uD83D\uDC62",
     "description": "womans boots",
     "aliases": [
       "boot"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👕",
+    "emojiChar": "👕",
+    "emoji": "\uD83D\uDC55",
     "description": "t-shirt",
     "aliases": [
       "shirt",
       "tshirt"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👔",
+    "emojiChar": "👔",
+    "emoji": "\uD83D\uDC54",
     "description": "necktie",
     "aliases": [
       "necktie"
@@ -1658,25 +1767,26 @@
     ]
   },
   {
-    "emoji": "👚",
+    "emojiChar": "👚",
+    "emoji": "\uD83D\uDC5A",
     "description": "womans clothes",
     "aliases": [
       "womans_clothes"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👗",
+    "emojiChar": "👗",
+    "emoji": "\uD83D\uDC57",
     "description": "dress",
     "aliases": [
       "dress"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎽",
+    "emojiChar": "🎽",
+    "emoji": "\uD83C\uDFBD",
     "description": "running shirt with sash",
     "aliases": [
       "running_shirt_with_sash"
@@ -1686,7 +1796,8 @@
     ]
   },
   {
-    "emoji": "👖",
+    "emojiChar": "👖",
+    "emoji": "\uD83D\uDC56",
     "description": "jeans",
     "aliases": [
       "jeans"
@@ -1696,16 +1807,17 @@
     ]
   },
   {
-    "emoji": "👘",
+    "emojiChar": "👘",
+    "emoji": "\uD83D\uDC58",
     "description": "kimono",
     "aliases": [
       "kimono"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👙",
+    "emojiChar": "👙",
+    "emoji": "\uD83D\uDC59",
     "description": "bikini",
     "aliases": [
       "bikini"
@@ -1715,7 +1827,8 @@
     ]
   },
   {
-    "emoji": "💼",
+    "emojiChar": "💼",
+    "emoji": "\uD83D\uDCBC",
     "description": "briefcase",
     "aliases": [
       "briefcase"
@@ -1725,7 +1838,8 @@
     ]
   },
   {
-    "emoji": "👜",
+    "emojiChar": "👜",
+    "emoji": "\uD83D\uDC5C",
     "description": "handbag",
     "aliases": [
       "handbag"
@@ -1735,7 +1849,8 @@
     ]
   },
   {
-    "emoji": "👝",
+    "emojiChar": "👝",
+    "emoji": "\uD83D\uDC5D",
     "description": "pouch",
     "aliases": [
       "pouch"
@@ -1745,16 +1860,17 @@
     ]
   },
   {
-    "emoji": "👛",
+    "emojiChar": "👛",
+    "emoji": "\uD83D\uDC5B",
     "description": "purse",
     "aliases": [
       "purse"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "👓",
+    "emojiChar": "👓",
+    "emoji": "\uD83D\uDC53",
     "description": "eyeglasses",
     "aliases": [
       "eyeglasses"
@@ -1764,16 +1880,17 @@
     ]
   },
   {
-    "emoji": "🎀",
+    "emojiChar": "🎀",
+    "emoji": "\uD83C\uDF80",
     "description": "ribbon",
     "aliases": [
       "ribbon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌂",
+    "emojiChar": "🌂",
+    "emoji": "\uD83C\uDF02",
     "description": "closed umbrella",
     "aliases": [
       "closed_umbrella"
@@ -1784,7 +1901,8 @@
     ]
   },
   {
-    "emoji": "💄",
+    "emojiChar": "💄",
+    "emoji": "\uD83D\uDC84",
     "description": "lipstick",
     "aliases": [
       "lipstick"
@@ -1794,43 +1912,44 @@
     ]
   },
   {
-    "emoji": "💛",
+    "emojiChar": "💛",
+    "emoji": "\uD83D\uDC9B",
     "description": "yellow heart",
     "aliases": [
       "yellow_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💙",
+    "emojiChar": "💙",
+    "emoji": "\uD83D\uDC99",
     "description": "blue heart",
     "aliases": [
       "blue_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💜",
+    "emojiChar": "💜",
+    "emoji": "\uD83D\uDC9C",
     "description": "purple heart",
     "aliases": [
       "purple_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💚",
+    "emojiChar": "💚",
+    "emoji": "\uD83D\uDC9A",
     "description": "green heart",
     "aliases": [
       "green_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "❤",
+    "emojiChar": "❤",
+    "emoji": "\u2764",
     "description": "heavy black heart",
     "aliases": [
       "heart"
@@ -1840,61 +1959,62 @@
     ]
   },
   {
-    "emoji": "💔",
+    "emojiChar": "💔",
+    "emoji": "\uD83D\uDC94",
     "description": "broken heart",
     "aliases": [
       "broken_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💗",
+    "emojiChar": "💗",
+    "emoji": "\uD83D\uDC97",
     "description": "growing heart",
     "aliases": [
       "heartpulse"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💓",
+    "emojiChar": "💓",
+    "emoji": "\uD83D\uDC93",
     "description": "beating heart",
     "aliases": [
       "heartbeat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💕",
+    "emojiChar": "💕",
+    "emoji": "\uD83D\uDC95",
     "description": "two hearts",
     "aliases": [
       "two_hearts"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💖",
+    "emojiChar": "💖",
+    "emoji": "\uD83D\uDC96",
     "description": "sparkling heart",
     "aliases": [
       "sparkling_heart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💞",
+    "emojiChar": "💞",
+    "emoji": "\uD83D\uDC9E",
     "description": "revolving hearts",
     "aliases": [
       "revolving_hearts"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💘",
+    "emojiChar": "💘",
+    "emoji": "\uD83D\uDC98",
     "description": "heart with arrow",
     "aliases": [
       "cupid"
@@ -1905,7 +2025,8 @@
     ]
   },
   {
-    "emoji": "💌",
+    "emojiChar": "💌",
+    "emoji": "\uD83D\uDC8C",
     "description": "love letter",
     "aliases": [
       "love_letter"
@@ -1916,7 +2037,8 @@
     ]
   },
   {
-    "emoji": "💋",
+    "emojiChar": "💋",
+    "emoji": "\uD83D\uDC8B",
     "description": "kiss mark",
     "aliases": [
       "kiss"
@@ -1926,7 +2048,8 @@
     ]
   },
   {
-    "emoji": "💍",
+    "emojiChar": "💍",
+    "emoji": "\uD83D\uDC8D",
     "description": "ring",
     "aliases": [
       "ring"
@@ -1938,7 +2061,8 @@
     ]
   },
   {
-    "emoji": "💎",
+    "emojiChar": "💎",
+    "emoji": "\uD83D\uDC8E",
     "description": "gem stone",
     "aliases": [
       "gem"
@@ -1948,7 +2072,8 @@
     ]
   },
   {
-    "emoji": "👤",
+    "emojiChar": "👤",
+    "emoji": "\uD83D\uDC64",
     "description": "bust in silhouette",
     "aliases": [
       "bust_in_silhouette"
@@ -1958,7 +2083,8 @@
     ]
   },
   {
-    "emoji": "👥",
+    "emojiChar": "👥",
+    "emoji": "\uD83D\uDC65",
     "description": "busts in silhouette",
     "aliases": [
       "busts_in_silhouette"
@@ -1970,7 +2096,8 @@
     ]
   },
   {
-    "emoji": "💬",
+    "emojiChar": "💬",
+    "emoji": "\uD83D\uDCAC",
     "description": "speech balloon",
     "aliases": [
       "speech_balloon"
@@ -1980,7 +2107,8 @@
     ]
   },
   {
-    "emoji": "👣",
+    "emojiChar": "👣",
+    "emoji": "\uD83D\uDC63",
     "description": "footprints",
     "aliases": [
       "footprints"
@@ -1991,7 +2119,8 @@
     ]
   },
   {
-    "emoji": "💭",
+    "emojiChar": "💭",
+    "emoji": "\uD83D\uDCAD",
     "description": "thought balloon",
     "aliases": [
       "thought_balloon"
@@ -2001,7 +2130,8 @@
     ]
   },
   {
-    "emoji": "🐶",
+    "emojiChar": "🐶",
+    "emoji": "\uD83D\uDC36",
     "description": "dog face",
     "aliases": [
       "dog"
@@ -2011,16 +2141,17 @@
     ]
   },
   {
-    "emoji": "🐺",
+    "emojiChar": "🐺",
+    "emoji": "\uD83D\uDC3A",
     "description": "wolf face",
     "aliases": [
       "wolf"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐱",
+    "emojiChar": "🐱",
+    "emoji": "\uD83D\uDC31",
     "description": "cat face",
     "aliases": [
       "cat"
@@ -2030,16 +2161,17 @@
     ]
   },
   {
-    "emoji": "🐭",
+    "emojiChar": "🐭",
+    "emoji": "\uD83D\uDC2D",
     "description": "mouse face",
     "aliases": [
       "mouse"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐹",
+    "emojiChar": "🐹",
+    "emoji": "\uD83D\uDC39",
     "description": "hamster face",
     "aliases": [
       "hamster"
@@ -2049,7 +2181,8 @@
     ]
   },
   {
-    "emoji": "🐰",
+    "emojiChar": "🐰",
+    "emoji": "\uD83D\uDC30",
     "description": "rabbit face",
     "aliases": [
       "rabbit"
@@ -2059,196 +2192,197 @@
     ]
   },
   {
-    "emoji": "🐸",
+    "emojiChar": "🐸",
+    "emoji": "\uD83D\uDC38",
     "description": "frog face",
     "aliases": [
       "frog"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐯",
+    "emojiChar": "🐯",
+    "emoji": "\uD83D\uDC2F",
     "description": "tiger face",
     "aliases": [
       "tiger"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐨",
+    "emojiChar": "🐨",
+    "emoji": "\uD83D\uDC28",
     "description": "koala",
     "aliases": [
       "koala"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐻",
+    "emojiChar": "🐻",
+    "emoji": "\uD83D\uDC3B",
     "description": "bear face",
     "aliases": [
       "bear"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐷",
+    "emojiChar": "🐷",
+    "emoji": "\uD83D\uDC37",
     "description": "pig face",
     "aliases": [
       "pig"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐽",
+    "emojiChar": "🐽",
+    "emoji": "\uD83D\uDC3D",
     "description": "pig nose",
     "aliases": [
       "pig_nose"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐮",
+    "emojiChar": "🐮",
+    "emoji": "\uD83D\uDC2E",
     "description": "cow face",
     "aliases": [
       "cow"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐗",
+    "emojiChar": "🐗",
+    "emoji": "\uD83D\uDC17",
     "description": "boar",
     "aliases": [
       "boar"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐵",
+    "emojiChar": "🐵",
+    "emoji": "\uD83D\uDC35",
     "description": "monkey face",
     "aliases": [
       "monkey_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐒",
+    "emojiChar": "🐒",
+    "emoji": "\uD83D\uDC12",
     "description": "monkey",
     "aliases": [
       "monkey"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐴",
+    "emojiChar": "🐴",
+    "emoji": "\uD83D\uDC34",
     "description": "horse face",
     "aliases": [
       "horse"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐑",
+    "emojiChar": "🐑",
+    "emoji": "\uD83D\uDC11",
     "description": "sheep",
     "aliases": [
       "sheep"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐘",
+    "emojiChar": "🐘",
+    "emoji": "\uD83D\uDC18",
     "description": "elephant",
     "aliases": [
       "elephant"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐼",
+    "emojiChar": "🐼",
+    "emoji": "\uD83D\uDC3C",
     "description": "panda face",
     "aliases": [
       "panda_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐧",
+    "emojiChar": "🐧",
+    "emoji": "\uD83D\uDC27",
     "description": "penguin",
     "aliases": [
       "penguin"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐦",
+    "emojiChar": "🐦",
+    "emoji": "\uD83D\uDC26",
     "description": "bird",
     "aliases": [
       "bird"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐤",
+    "emojiChar": "🐤",
+    "emoji": "\uD83D\uDC24",
     "description": "baby chick",
     "aliases": [
       "baby_chick"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐥",
+    "emojiChar": "🐥",
+    "emoji": "\uD83D\uDC25",
     "description": "front-facing baby chick",
     "aliases": [
       "hatched_chick"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐣",
+    "emojiChar": "🐣",
+    "emoji": "\uD83D\uDC23",
     "description": "hatching chick",
     "aliases": [
       "hatching_chick"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐔",
+    "emojiChar": "🐔",
+    "emoji": "\uD83D\uDC14",
     "description": "chicken",
     "aliases": [
       "chicken"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐍",
+    "emojiChar": "🐍",
+    "emoji": "\uD83D\uDC0D",
     "description": "snake",
     "aliases": [
       "snake"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐢",
+    "emojiChar": "🐢",
+    "emoji": "\uD83D\uDC22",
     "description": "turtle",
     "aliases": [
       "turtle"
@@ -2258,35 +2392,36 @@
     ]
   },
   {
-    "emoji": "🐛",
+    "emojiChar": "🐛",
+    "emoji": "\uD83D\uDC1B",
     "description": "bug",
     "aliases": [
       "bug"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐝",
+    "emojiChar": "🐝",
+    "emoji": "\uD83D\uDC1D",
     "description": "honeybee",
     "aliases": [
       "bee",
       "honeybee"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐜",
+    "emojiChar": "🐜",
+    "emoji": "\uD83D\uDC1C",
     "description": "ant",
     "aliases": [
       "ant"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐞",
+    "emojiChar": "🐞",
+    "emoji": "\uD83D\uDC1E",
     "description": "lady beetle",
     "aliases": [
       "beetle"
@@ -2296,7 +2431,8 @@
     ]
   },
   {
-    "emoji": "🐌",
+    "emojiChar": "🐌",
+    "emoji": "\uD83D\uDC0C",
     "description": "snail",
     "aliases": [
       "snail"
@@ -2306,16 +2442,17 @@
     ]
   },
   {
-    "emoji": "🐙",
+    "emojiChar": "🐙",
+    "emoji": "\uD83D\uDC19",
     "description": "octopus",
     "aliases": [
       "octopus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐚",
+    "emojiChar": "🐚",
+    "emoji": "\uD83D\uDC1A",
     "description": "spiral shell",
     "aliases": [
       "shell"
@@ -2326,35 +2463,36 @@
     ]
   },
   {
-    "emoji": "🐠",
+    "emojiChar": "🐠",
+    "emoji": "\uD83D\uDC20",
     "description": "tropical fish",
     "aliases": [
       "tropical_fish"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐟",
+    "emojiChar": "🐟",
+    "emoji": "\uD83D\uDC1F",
     "description": "fish",
     "aliases": [
       "fish"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐬",
+    "emojiChar": "🐬",
+    "emoji": "\uD83D\uDC2C",
     "description": "dolphin",
     "aliases": [
       "dolphin",
       "flipper"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐳",
+    "emojiChar": "🐳",
+    "emoji": "\uD83D\uDC33",
     "description": "spouting whale",
     "aliases": [
       "whale"
@@ -2364,79 +2502,80 @@
     ]
   },
   {
-    "emoji": "🐋",
+    "emojiChar": "🐋",
+    "emoji": "\uD83D\uDC0B",
     "description": "whale",
     "aliases": [
       "whale2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐄",
+    "emojiChar": "🐄",
+    "emoji": "\uD83D\uDC04",
     "description": "cow",
     "aliases": [
       "cow2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐏",
+    "emojiChar": "🐏",
+    "emoji": "\uD83D\uDC0F",
     "description": "ram",
     "aliases": [
       "ram"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐀",
+    "emojiChar": "🐀",
+    "emoji": "\uD83D\uDC00",
     "description": "rat",
     "aliases": [
       "rat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐃",
+    "emojiChar": "🐃",
+    "emoji": "\uD83D\uDC03",
     "description": "water buffalo",
     "aliases": [
       "water_buffalo"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐅",
+    "emojiChar": "🐅",
+    "emoji": "\uD83D\uDC05",
     "description": "tiger",
     "aliases": [
       "tiger2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐇",
+    "emojiChar": "🐇",
+    "emoji": "\uD83D\uDC07",
     "description": "rabbit",
     "aliases": [
       "rabbit2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐉",
+    "emojiChar": "🐉",
+    "emoji": "\uD83D\uDC09",
     "description": "dragon",
     "aliases": [
       "dragon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐎",
+    "emojiChar": "🐎",
+    "emoji": "\uD83D\uDC0E",
     "description": "horse",
     "aliases": [
       "racehorse"
@@ -2446,97 +2585,98 @@
     ]
   },
   {
-    "emoji": "🐐",
+    "emojiChar": "🐐",
+    "emoji": "\uD83D\uDC10",
     "description": "goat",
     "aliases": [
       "goat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐓",
+    "emojiChar": "🐓",
+    "emoji": "\uD83D\uDC13",
     "description": "rooster",
     "aliases": [
       "rooster"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐕",
+    "emojiChar": "🐕",
+    "emoji": "\uD83D\uDC15",
     "description": "dog",
     "aliases": [
       "dog2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐖",
+    "emojiChar": "🐖",
+    "emoji": "\uD83D\uDC16",
     "description": "pig",
     "aliases": [
       "pig2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐁",
+    "emojiChar": "🐁",
+    "emoji": "\uD83D\uDC01",
     "description": "mouse",
     "aliases": [
       "mouse2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐂",
+    "emojiChar": "🐂",
+    "emoji": "\uD83D\uDC02",
     "description": "ox",
     "aliases": [
       "ox"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐲",
+    "emojiChar": "🐲",
+    "emoji": "\uD83D\uDC32",
     "description": "dragon face",
     "aliases": [
       "dragon_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐡",
+    "emojiChar": "🐡",
+    "emoji": "\uD83D\uDC21",
     "description": "blowfish",
     "aliases": [
       "blowfish"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐊",
+    "emojiChar": "🐊",
+    "emoji": "\uD83D\uDC0A",
     "description": "crocodile",
     "aliases": [
       "crocodile"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐫",
+    "emojiChar": "🐫",
+    "emoji": "\uD83D\uDC2B",
     "description": "bactrian camel",
     "aliases": [
       "camel"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐪",
+    "emojiChar": "🐪",
+    "emoji": "\uD83D\uDC2A",
     "description": "dromedary camel",
     "aliases": [
       "dromedary_camel"
@@ -2546,25 +2686,26 @@
     ]
   },
   {
-    "emoji": "🐆",
+    "emojiChar": "🐆",
+    "emoji": "\uD83D\uDC06",
     "description": "leopard",
     "aliases": [
       "leopard"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐈",
+    "emojiChar": "🐈",
+    "emoji": "\uD83D\uDC08",
     "description": "cat",
     "aliases": [
       "cat2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🐩",
+    "emojiChar": "🐩",
+    "emoji": "\uD83D\uDC29",
     "description": "poodle",
     "aliases": [
       "poodle"
@@ -2574,17 +2715,18 @@
     ]
   },
   {
-    "emoji": "🐾",
+    "emojiChar": "🐾",
+    "emoji": "\uD83D\uDC3E",
     "description": "paw prints",
     "aliases": [
       "feet",
       "paw_prints"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💐",
+    "emojiChar": "💐",
+    "emoji": "\uD83D\uDC90",
     "description": "bouquet",
     "aliases": [
       "bouquet"
@@ -2594,7 +2736,8 @@
     ]
   },
   {
-    "emoji": "🌸",
+    "emojiChar": "🌸",
+    "emoji": "\uD83C\uDF38",
     "description": "cherry blossom",
     "aliases": [
       "cherry_blossom"
@@ -2605,7 +2748,8 @@
     ]
   },
   {
-    "emoji": "🌷",
+    "emojiChar": "🌷",
+    "emoji": "\uD83C\uDF37",
     "description": "tulip",
     "aliases": [
       "tulip"
@@ -2615,7 +2759,8 @@
     ]
   },
   {
-    "emoji": "🍀",
+    "emojiChar": "🍀",
+    "emoji": "\uD83C\uDF40",
     "description": "four leaf clover",
     "aliases": [
       "four_leaf_clover"
@@ -2625,7 +2770,8 @@
     ]
   },
   {
-    "emoji": "🌹",
+    "emojiChar": "🌹",
+    "emoji": "\uD83C\uDF39",
     "description": "rose",
     "aliases": [
       "rose"
@@ -2635,25 +2781,26 @@
     ]
   },
   {
-    "emoji": "🌻",
+    "emojiChar": "🌻",
+    "emoji": "\uD83C\uDF3B",
     "description": "sunflower",
     "aliases": [
       "sunflower"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌺",
+    "emojiChar": "🌺",
+    "emoji": "\uD83C\uDF3A",
     "description": "hibiscus",
     "aliases": [
       "hibiscus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍁",
+    "emojiChar": "🍁",
+    "emoji": "\uD83C\uDF41",
     "description": "maple leaf",
     "aliases": [
       "maple_leaf"
@@ -2663,7 +2810,8 @@
     ]
   },
   {
-    "emoji": "🍃",
+    "emojiChar": "🍃",
+    "emoji": "\uD83C\uDF43",
     "description": "leaf fluttering in wind",
     "aliases": [
       "leaves"
@@ -2673,7 +2821,8 @@
     ]
   },
   {
-    "emoji": "🍂",
+    "emojiChar": "🍂",
+    "emoji": "\uD83C\uDF42",
     "description": "fallen leaf",
     "aliases": [
       "fallen_leaf"
@@ -2683,52 +2832,53 @@
     ]
   },
   {
-    "emoji": "🌿",
+    "emojiChar": "🌿",
+    "emoji": "\uD83C\uDF3F",
     "description": "herb",
     "aliases": [
       "herb"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌾",
+    "emojiChar": "🌾",
+    "emoji": "\uD83C\uDF3E",
     "description": "ear of rice",
     "aliases": [
       "ear_of_rice"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍄",
+    "emojiChar": "🍄",
+    "emoji": "\uD83C\uDF44",
     "description": "mushroom",
     "aliases": [
       "mushroom"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌵",
+    "emojiChar": "🌵",
+    "emoji": "\uD83C\uDF35",
     "description": "cactus",
     "aliases": [
       "cactus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌴",
+    "emojiChar": "🌴",
+    "emoji": "\uD83C\uDF34",
     "description": "palm tree",
     "aliases": [
       "palm_tree"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌲",
+    "emojiChar": "🌲",
+    "emoji": "\uD83C\uDF32",
     "description": "evergreen tree",
     "aliases": [
       "evergreen_tree"
@@ -2738,7 +2888,8 @@
     ]
   },
   {
-    "emoji": "🌳",
+    "emojiChar": "🌳",
+    "emoji": "\uD83C\uDF33",
     "description": "deciduous tree",
     "aliases": [
       "deciduous_tree"
@@ -2748,16 +2899,17 @@
     ]
   },
   {
-    "emoji": "🌰",
+    "emojiChar": "🌰",
+    "emoji": "\uD83C\uDF30",
     "description": "chestnut",
     "aliases": [
       "chestnut"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌱",
+    "emojiChar": "🌱",
+    "emoji": "\uD83C\uDF31",
     "description": "seedling",
     "aliases": [
       "seedling"
@@ -2767,16 +2919,17 @@
     ]
   },
   {
-    "emoji": "🌼",
+    "emojiChar": "🌼",
+    "emoji": "\uD83C\uDF3C",
     "description": "blossom",
     "aliases": [
       "blossom"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌐",
+    "emojiChar": "🌐",
+    "emoji": "\uD83C\uDF10",
     "description": "globe with meridians",
     "aliases": [
       "globe_with_meridians"
@@ -2788,7 +2941,8 @@
     ]
   },
   {
-    "emoji": "🌞",
+    "emojiChar": "🌞",
+    "emoji": "\uD83C\uDF1E",
     "description": "sun with face",
     "aliases": [
       "sun_with_face"
@@ -2798,116 +2952,117 @@
     ]
   },
   {
-    "emoji": "🌝",
+    "emojiChar": "🌝",
+    "emoji": "\uD83C\uDF1D",
     "description": "full moon with face",
     "aliases": [
       "full_moon_with_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌚",
+    "emojiChar": "🌚",
+    "emoji": "\uD83C\uDF1A",
     "description": "new moon with face",
     "aliases": [
       "new_moon_with_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌑",
+    "emojiChar": "🌑",
+    "emoji": "\uD83C\uDF11",
     "description": "new moon symbol",
     "aliases": [
       "new_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌒",
+    "emojiChar": "🌒",
+    "emoji": "\uD83C\uDF12",
     "description": "waxing crescent moon symbol",
     "aliases": [
       "waxing_crescent_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌓",
+    "emojiChar": "🌓",
+    "emoji": "\uD83C\uDF13",
     "description": "first quarter moon symbol",
     "aliases": [
       "first_quarter_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌔",
+    "emojiChar": "🌔",
+    "emoji": "\uD83C\uDF14",
     "description": "waxing gibbous moon symbol",
     "aliases": [
       "moon",
       "waxing_gibbous_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌕",
+    "emojiChar": "🌕",
+    "emoji": "\uD83C\uDF15",
     "description": "full moon symbol",
     "aliases": [
       "full_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌖",
+    "emojiChar": "🌖",
+    "emoji": "\uD83C\uDF16",
     "description": "waning gibbous moon symbol",
     "aliases": [
       "waning_gibbous_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌗",
+    "emojiChar": "🌗",
+    "emoji": "\uD83C\uDF17",
     "description": "last quarter moon symbol",
     "aliases": [
       "last_quarter_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌘",
+    "emojiChar": "🌘",
+    "emoji": "\uD83C\uDF18",
     "description": "waning crescent moon symbol",
     "aliases": [
       "waning_crescent_moon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌜",
+    "emojiChar": "🌜",
+    "emoji": "\uD83C\uDF1C",
     "description": "last quarter moon with face",
     "aliases": [
       "last_quarter_moon_with_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌛",
+    "emojiChar": "🌛",
+    "emoji": "\uD83C\uDF1B",
     "description": "first quarter moon with face",
     "aliases": [
       "first_quarter_moon_with_face"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌙",
+    "emojiChar": "🌙",
+    "emoji": "\uD83C\uDF19",
     "description": "crescent moon",
     "aliases": [
       "crescent_moon"
@@ -2917,7 +3072,8 @@
     ]
   },
   {
-    "emoji": "🌍",
+    "emojiChar": "🌍",
+    "emoji": "\uD83C\uDF0D",
     "description": "earth globe europe-africa",
     "aliases": [
       "earth_africa"
@@ -2929,7 +3085,8 @@
     ]
   },
   {
-    "emoji": "🌎",
+    "emojiChar": "🌎",
+    "emoji": "\uD83C\uDF0E",
     "description": "earth globe americas",
     "aliases": [
       "earth_americas"
@@ -2941,7 +3098,8 @@
     ]
   },
   {
-    "emoji": "🌏",
+    "emojiChar": "🌏",
+    "emoji": "\uD83C\uDF0F",
     "description": "earth globe asia-australia",
     "aliases": [
       "earth_asia"
@@ -2953,43 +3111,44 @@
     ]
   },
   {
-    "emoji": "🌋",
+    "emojiChar": "🌋",
+    "emoji": "\uD83C\uDF0B",
     "description": "volcano",
     "aliases": [
       "volcano"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌌",
+    "emojiChar": "🌌",
+    "emoji": "\uD83C\uDF0C",
     "description": "milky way",
     "aliases": [
       "milky_way"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌠",
+    "emojiChar": "🌠",
+    "emoji": "\uD83C\uDF20",
     "description": "shooting star",
     "aliases": [
       "stars"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⭐",
+    "emojiChar": "⭐",
+    "emoji": "\u2B50",
     "description": "white medium star",
     "aliases": [
       "star"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "☀",
+    "emojiChar": "☀",
+    "emoji": "\u2600",
     "description": "black sun with rays",
     "aliases": [
       "sunny"
@@ -2999,7 +3158,8 @@
     ]
   },
   {
-    "emoji": "⛅",
+    "emojiChar": "⛅",
+    "emoji": "\u26C5",
     "description": "sun behind cloud",
     "aliases": [
       "partly_sunny"
@@ -3010,16 +3170,17 @@
     ]
   },
   {
-    "emoji": "☁",
+    "emojiChar": "☁",
+    "emoji": "\u2601",
     "description": "cloud",
     "aliases": [
       "cloud"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⚡",
+    "emojiChar": "⚡",
+    "emoji": "\u26A1",
     "description": "high voltage sign",
     "aliases": [
       "zap"
@@ -3030,7 +3191,8 @@
     ]
   },
   {
-    "emoji": "☔",
+    "emojiChar": "☔",
+    "emoji": "\u2614",
     "description": "umbrella with rain drops",
     "aliases": [
       "umbrella"
@@ -3041,7 +3203,8 @@
     ]
   },
   {
-    "emoji": "❄",
+    "emojiChar": "❄",
+    "emoji": "\u2744",
     "description": "snowflake",
     "aliases": [
       "snowflake"
@@ -3053,7 +3216,8 @@
     ]
   },
   {
-    "emoji": "⛄",
+    "emojiChar": "⛄",
+    "emoji": "\u26C4",
     "description": "snowman without snow",
     "aliases": [
       "snowman"
@@ -3064,7 +3228,8 @@
     ]
   },
   {
-    "emoji": "🌀",
+    "emojiChar": "🌀",
+    "emoji": "\uD83C\uDF00",
     "description": "cyclone",
     "aliases": [
       "cyclone"
@@ -3074,7 +3239,8 @@
     ]
   },
   {
-    "emoji": "🌁",
+    "emojiChar": "🌁",
+    "emoji": "\uD83C\uDF01",
     "description": "foggy",
     "aliases": [
       "foggy"
@@ -3084,7 +3250,8 @@
     ]
   },
   {
-    "emoji": "🌈",
+    "emojiChar": "🌈",
+    "emoji": "\uD83C\uDF08",
     "description": "rainbow",
     "aliases": [
       "rainbow"
@@ -3094,7 +3261,8 @@
     ]
   },
   {
-    "emoji": "🌊",
+    "emojiChar": "🌊",
+    "emoji": "\uD83C\uDF0A",
     "description": "water wave",
     "aliases": [
       "ocean"
@@ -3104,16 +3272,17 @@
     ]
   },
   {
-    "emoji": "🎍",
+    "emojiChar": "🎍",
+    "emoji": "\uD83C\uDF8D",
     "description": "pine decoration",
     "aliases": [
       "bamboo"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💝",
+    "emojiChar": "💝",
+    "emoji": "\uD83D\uDC9D",
     "description": "heart with ribbon",
     "aliases": [
       "gift_heart"
@@ -3123,25 +3292,26 @@
     ]
   },
   {
-    "emoji": "🎎",
+    "emojiChar": "🎎",
+    "emoji": "\uD83C\uDF8E",
     "description": "japanese dolls",
     "aliases": [
       "dolls"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎒",
+    "emojiChar": "🎒",
+    "emoji": "\uD83C\uDF92",
     "description": "school satchel",
     "aliases": [
       "school_satchel"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎓",
+    "emojiChar": "🎓",
+    "emoji": "\uD83C\uDF93",
     "description": "graduation cap",
     "aliases": [
       "mortar_board"
@@ -3154,16 +3324,17 @@
     ]
   },
   {
-    "emoji": "🎏",
+    "emojiChar": "🎏",
+    "emoji": "\uD83C\uDF8F",
     "description": "carp streamer",
     "aliases": [
       "flags"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎆",
+    "emojiChar": "🎆",
+    "emoji": "\uD83C\uDF86",
     "description": "fireworks",
     "aliases": [
       "fireworks"
@@ -3174,34 +3345,35 @@
     ]
   },
   {
-    "emoji": "🎇",
+    "emojiChar": "🎇",
+    "emoji": "\uD83C\uDF87",
     "description": "firework sparkler",
     "aliases": [
       "sparkler"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎐",
+    "emojiChar": "🎐",
+    "emoji": "\uD83C\uDF90",
     "description": "wind chime",
     "aliases": [
       "wind_chime"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎑",
+    "emojiChar": "🎑",
+    "emoji": "\uD83C\uDF91",
     "description": "moon viewing ceremony",
     "aliases": [
       "rice_scene"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎃",
+    "emojiChar": "🎃",
+    "emoji": "\uD83C\uDF83",
     "description": "jack-o-lantern",
     "aliases": [
       "jack_o_lantern"
@@ -3211,7 +3383,8 @@
     ]
   },
   {
-    "emoji": "👻",
+    "emojiChar": "👻",
+    "emoji": "\uD83D\uDC7B",
     "description": "ghost",
     "aliases": [
       "ghost"
@@ -3221,7 +3394,8 @@
     ]
   },
   {
-    "emoji": "🎅",
+    "emojiChar": "🎅",
+    "emoji": "\uD83C\uDF85",
     "description": "father christmas",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -3232,16 +3406,17 @@
     ]
   },
   {
-    "emoji": "🎄",
+    "emojiChar": "🎄",
+    "emoji": "\uD83C\uDF84",
     "description": "christmas tree",
     "aliases": [
       "christmas_tree"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎁",
+    "emojiChar": "🎁",
+    "emoji": "\uD83C\uDF81",
     "description": "wrapped present",
     "aliases": [
       "gift"
@@ -3253,16 +3428,17 @@
     ]
   },
   {
-    "emoji": "🎋",
+    "emojiChar": "🎋",
+    "emoji": "\uD83C\uDF8B",
     "description": "tanabata tree",
     "aliases": [
       "tanabata_tree"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎉",
+    "emojiChar": "🎉",
+    "emoji": "\uD83C\uDF89",
     "description": "party popper",
     "aliases": [
       "tada"
@@ -3272,16 +3448,17 @@
     ]
   },
   {
-    "emoji": "🎊",
+    "emojiChar": "🎊",
+    "emoji": "\uD83C\uDF8A",
     "description": "confetti ball",
     "aliases": [
       "confetti_ball"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎈",
+    "emojiChar": "🎈",
+    "emoji": "\uD83C\uDF88",
     "description": "balloon",
     "aliases": [
       "balloon"
@@ -3292,16 +3469,17 @@
     ]
   },
   {
-    "emoji": "🎌",
+    "emojiChar": "🎌",
+    "emoji": "\uD83C\uDF8C",
     "description": "crossed flags",
     "aliases": [
       "crossed_flags"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔮",
+    "emojiChar": "🔮",
+    "emoji": "\uD83D\uDD2E",
     "description": "crystal ball",
     "aliases": [
       "crystal_ball"
@@ -3311,7 +3489,8 @@
     ]
   },
   {
-    "emoji": "🎥",
+    "emojiChar": "🎥",
+    "emoji": "\uD83C\uDFA5",
     "description": "movie camera",
     "aliases": [
       "movie_camera"
@@ -3322,7 +3501,8 @@
     ]
   },
   {
-    "emoji": "📷",
+    "emojiChar": "📷",
+    "emoji": "\uD83D\uDCF7",
     "description": "camera",
     "aliases": [
       "camera"
@@ -3332,52 +3512,53 @@
     ]
   },
   {
-    "emoji": "📹",
+    "emojiChar": "📹",
+    "emoji": "\uD83D\uDCF9",
     "description": "video camera",
     "aliases": [
       "video_camera"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📼",
+    "emojiChar": "📼",
+    "emoji": "\uD83D\uDCFC",
     "description": "videocassette",
     "aliases": [
       "vhs"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💿",
+    "emojiChar": "💿",
+    "emoji": "\uD83D\uDCBF",
     "description": "optical disc",
     "aliases": [
       "cd"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📀",
+    "emojiChar": "📀",
+    "emoji": "\uD83D\uDCC0",
     "description": "dvd",
     "aliases": [
       "dvd"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💽",
+    "emojiChar": "💽",
+    "emoji": "\uD83D\uDCBD",
     "description": "minidisc",
     "aliases": [
       "minidisc"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💾",
+    "emojiChar": "💾",
+    "emoji": "\uD83D\uDCBE",
     "description": "floppy disk",
     "aliases": [
       "floppy_disk"
@@ -3387,7 +3568,8 @@
     ]
   },
   {
-    "emoji": "💻",
+    "emojiChar": "💻",
+    "emoji": "\uD83D\uDCBB",
     "description": "personal computer",
     "aliases": [
       "computer"
@@ -3398,7 +3580,8 @@
     ]
   },
   {
-    "emoji": "📱",
+    "emojiChar": "📱",
+    "emoji": "\uD83D\uDCF1",
     "description": "mobile phone",
     "aliases": [
       "iphone"
@@ -3409,17 +3592,18 @@
     ]
   },
   {
-    "emoji": "☎",
+    "emojiChar": "☎",
+    "emoji": "\u260E",
     "description": "black telephone",
     "aliases": [
       "phone",
       "telephone"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📞",
+    "emojiChar": "📞",
+    "emoji": "\uD83D\uDCDE",
     "description": "telephone receiver",
     "aliases": [
       "telephone_receiver"
@@ -3430,25 +3614,26 @@
     ]
   },
   {
-    "emoji": "📟",
+    "emojiChar": "📟",
+    "emoji": "\uD83D\uDCDF",
     "description": "pager",
     "aliases": [
       "pager"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📠",
+    "emojiChar": "📠",
+    "emoji": "\uD83D\uDCE0",
     "description": "fax machine",
     "aliases": [
       "fax"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📡",
+    "emojiChar": "📡",
+    "emoji": "\uD83D\uDCE1",
     "description": "satellite antenna",
     "aliases": [
       "satellite_antenna"
@@ -3458,16 +3643,17 @@
     ]
   },
   {
-    "emoji": "📺",
+    "emojiChar": "📺",
+    "emoji": "\uD83D\uDCFA",
     "description": "television",
     "aliases": [
       "tv"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📻",
+    "emojiChar": "📻",
+    "emoji": "\uD83D\uDCFB",
     "description": "radio",
     "aliases": [
       "radio"
@@ -3477,7 +3663,8 @@
     ]
   },
   {
-    "emoji": "🔊",
+    "emojiChar": "🔊",
+    "emoji": "\uD83D\uDD0A",
     "description": "speaker with three sound waves",
     "aliases": [
       "loud_sound"
@@ -3487,7 +3674,8 @@
     ]
   },
   {
-    "emoji": "🔉",
+    "emojiChar": "🔉",
+    "emoji": "\uD83D\uDD09",
     "description": "speaker with one sound wave",
     "aliases": [
       "sound"
@@ -3497,16 +3685,17 @@
     ]
   },
   {
-    "emoji": "🔈",
+    "emojiChar": "🔈",
+    "emoji": "\uD83D\uDD08",
     "description": "speaker",
     "aliases": [
       "speaker"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔇",
+    "emojiChar": "🔇",
+    "emoji": "\uD83D\uDD07",
     "description": "speaker with cancellation stroke",
     "aliases": [
       "mute"
@@ -3517,7 +3706,8 @@
     ]
   },
   {
-    "emoji": "🔔",
+    "emojiChar": "🔔",
+    "emoji": "\uD83D\uDD14",
     "description": "bell",
     "aliases": [
       "bell"
@@ -3528,7 +3718,8 @@
     ]
   },
   {
-    "emoji": "🔕",
+    "emojiChar": "🔕",
+    "emoji": "\uD83D\uDD15",
     "description": "bell with cancellation stroke",
     "aliases": [
       "no_bell"
@@ -3539,7 +3730,8 @@
     ]
   },
   {
-    "emoji": "📢",
+    "emojiChar": "📢",
+    "emoji": "\uD83D\uDCE2",
     "description": "public address loudspeaker",
     "aliases": [
       "loudspeaker"
@@ -3549,16 +3741,17 @@
     ]
   },
   {
-    "emoji": "📣",
+    "emojiChar": "📣",
+    "emoji": "\uD83D\uDCE3",
     "description": "cheering megaphone",
     "aliases": [
       "mega"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⏳",
+    "emojiChar": "⏳",
+    "emoji": "\u23F3",
     "description": "hourglass with flowing sand",
     "aliases": [
       "hourglass_flowing_sand"
@@ -3568,7 +3761,8 @@
     ]
   },
   {
-    "emoji": "⌛",
+    "emojiChar": "⌛",
+    "emoji": "\u231B",
     "description": "hourglass",
     "aliases": [
       "hourglass"
@@ -3578,7 +3772,8 @@
     ]
   },
   {
-    "emoji": "⏰",
+    "emojiChar": "⏰",
+    "emoji": "\u23F0",
     "description": "alarm clock",
     "aliases": [
       "alarm_clock"
@@ -3588,7 +3783,8 @@
     ]
   },
   {
-    "emoji": "⌚",
+    "emojiChar": "⌚",
+    "emoji": "\u231A",
     "description": "watch",
     "aliases": [
       "watch"
@@ -3598,7 +3794,8 @@
     ]
   },
   {
-    "emoji": "🔓",
+    "emojiChar": "🔓",
+    "emoji": "\uD83D\uDD13",
     "description": "open lock",
     "aliases": [
       "unlock"
@@ -3608,7 +3805,8 @@
     ]
   },
   {
-    "emoji": "🔒",
+    "emojiChar": "🔒",
+    "emoji": "\uD83D\uDD12",
     "description": "lock",
     "aliases": [
       "lock"
@@ -3619,16 +3817,17 @@
     ]
   },
   {
-    "emoji": "🔏",
+    "emojiChar": "🔏",
+    "emoji": "\uD83D\uDD0F",
     "description": "lock with ink pen",
     "aliases": [
       "lock_with_ink_pen"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔐",
+    "emojiChar": "🔐",
+    "emoji": "\uD83D\uDD10",
     "description": "closed lock with key",
     "aliases": [
       "closed_lock_with_key"
@@ -3638,7 +3837,8 @@
     ]
   },
   {
-    "emoji": "🔑",
+    "emojiChar": "🔑",
+    "emoji": "\uD83D\uDD11",
     "description": "key",
     "aliases": [
       "key"
@@ -3649,16 +3849,17 @@
     ]
   },
   {
-    "emoji": "🔎",
+    "emojiChar": "🔎",
+    "emoji": "\uD83D\uDD0E",
     "description": "right-pointing magnifying glass",
     "aliases": [
       "mag_right"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💡",
+    "emojiChar": "💡",
+    "emoji": "\uD83D\uDCA1",
     "description": "electric light bulb",
     "aliases": [
       "bulb"
@@ -3669,43 +3870,44 @@
     ]
   },
   {
-    "emoji": "🔦",
+    "emojiChar": "🔦",
+    "emoji": "\uD83D\uDD26",
     "description": "electric torch",
     "aliases": [
       "flashlight"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔆",
+    "emojiChar": "🔆",
+    "emoji": "\uD83D\uDD06",
     "description": "high brightness symbol",
     "aliases": [
       "high_brightness"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔅",
+    "emojiChar": "🔅",
+    "emoji": "\uD83D\uDD05",
     "description": "low brightness symbol",
     "aliases": [
       "low_brightness"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔌",
+    "emojiChar": "🔌",
+    "emoji": "\uD83D\uDD0C",
     "description": "electric plug",
     "aliases": [
       "electric_plug"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔋",
+    "emojiChar": "🔋",
+    "emoji": "\uD83D\uDD0B",
     "description": "battery",
     "aliases": [
       "battery"
@@ -3715,7 +3917,8 @@
     ]
   },
   {
-    "emoji": "🔍",
+    "emojiChar": "🔍",
+    "emoji": "\uD83D\uDD0D",
     "description": "left-pointing magnifying glass",
     "aliases": [
       "mag"
@@ -3726,16 +3929,17 @@
     ]
   },
   {
-    "emoji": "🛁",
+    "emojiChar": "🛁",
+    "emoji": "\uD83D\uDEC1",
     "description": "bathtub",
     "aliases": [
       "bathtub"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🛀",
+    "emojiChar": "🛀",
+    "emoji": "\uD83D\uDEC0",
     "description": "bath",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -3746,7 +3950,8 @@
     ]
   },
   {
-    "emoji": "🚿",
+    "emojiChar": "🚿",
+    "emoji": "\uD83D\uDEBF",
     "description": "shower",
     "aliases": [
       "shower"
@@ -3756,7 +3961,8 @@
     ]
   },
   {
-    "emoji": "🚽",
+    "emojiChar": "🚽",
+    "emoji": "\uD83D\uDEBD",
     "description": "toilet",
     "aliases": [
       "toilet"
@@ -3766,7 +3972,8 @@
     ]
   },
   {
-    "emoji": "🔧",
+    "emojiChar": "🔧",
+    "emoji": "\uD83D\uDD27",
     "description": "wrench",
     "aliases": [
       "wrench"
@@ -3776,16 +3983,17 @@
     ]
   },
   {
-    "emoji": "🔩",
+    "emojiChar": "🔩",
+    "emoji": "\uD83D\uDD29",
     "description": "nut and bolt",
     "aliases": [
       "nut_and_bolt"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔨",
+    "emojiChar": "🔨",
+    "emoji": "\uD83D\uDD28",
     "description": "hammer",
     "aliases": [
       "hammer"
@@ -3795,16 +4003,17 @@
     ]
   },
   {
-    "emoji": "🚪",
+    "emojiChar": "🚪",
+    "emoji": "\uD83D\uDEAA",
     "description": "door",
     "aliases": [
       "door"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚬",
+    "emojiChar": "🚬",
+    "emoji": "\uD83D\uDEAC",
     "description": "smoking symbol",
     "aliases": [
       "smoking"
@@ -3814,7 +4023,8 @@
     ]
   },
   {
-    "emoji": "💣",
+    "emojiChar": "💣",
+    "emoji": "\uD83D\uDCA3",
     "description": "bomb",
     "aliases": [
       "bomb"
@@ -3824,7 +4034,8 @@
     ]
   },
   {
-    "emoji": "🔫",
+    "emojiChar": "🔫",
+    "emoji": "\uD83D\uDD2B",
     "description": "pistol",
     "aliases": [
       "gun"
@@ -3835,7 +4046,8 @@
     ]
   },
   {
-    "emoji": "🔪",
+    "emojiChar": "🔪",
+    "emoji": "\uD83D\uDD2A",
     "description": "hocho",
     "aliases": [
       "hocho",
@@ -3847,7 +4059,8 @@
     ]
   },
   {
-    "emoji": "💊",
+    "emojiChar": "💊",
+    "emoji": "\uD83D\uDC8A",
     "description": "pill",
     "aliases": [
       "pill"
@@ -3858,7 +4071,8 @@
     ]
   },
   {
-    "emoji": "💉",
+    "emojiChar": "💉",
+    "emoji": "\uD83D\uDC89",
     "description": "syringe",
     "aliases": [
       "syringe"
@@ -3870,7 +4084,8 @@
     ]
   },
   {
-    "emoji": "💰",
+    "emojiChar": "💰",
+    "emoji": "\uD83D\uDCB0",
     "description": "money bag",
     "aliases": [
       "moneybag"
@@ -3881,16 +4096,17 @@
     ]
   },
   {
-    "emoji": "💴",
+    "emojiChar": "💴",
+    "emoji": "\uD83D\uDCB4",
     "description": "banknote with yen sign",
     "aliases": [
       "yen"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💵",
+    "emojiChar": "💵",
+    "emoji": "\uD83D\uDCB5",
     "description": "banknote with dollar sign",
     "aliases": [
       "dollar"
@@ -3900,25 +4116,26 @@
     ]
   },
   {
-    "emoji": "💷",
+    "emojiChar": "💷",
+    "emoji": "\uD83D\uDCB7",
     "description": "banknote with pound sign",
     "aliases": [
       "pound"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💶",
+    "emojiChar": "💶",
+    "emoji": "\uD83D\uDCB6",
     "description": "banknote with euro sign",
     "aliases": [
       "euro"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💳",
+    "emojiChar": "💳",
+    "emoji": "\uD83D\uDCB3",
     "description": "credit card",
     "aliases": [
       "credit_card"
@@ -3928,7 +4145,8 @@
     ]
   },
   {
-    "emoji": "💸",
+    "emojiChar": "💸",
+    "emoji": "\uD83D\uDCB8",
     "description": "money with wings",
     "aliases": [
       "money_with_wings"
@@ -3938,7 +4156,8 @@
     ]
   },
   {
-    "emoji": "📲",
+    "emojiChar": "📲",
+    "emoji": "\uD83D\uDCF2",
     "description": "mobile phone with rightwards arrow at left",
     "aliases": [
       "calling"
@@ -3949,34 +4168,35 @@
     ]
   },
   {
-    "emoji": "📧",
+    "emojiChar": "📧",
+    "emoji": "\uD83D\uDCE7",
     "description": "e-mail symbol",
     "aliases": [
       "e-mail"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📥",
+    "emojiChar": "📥",
+    "emoji": "\uD83D\uDCE5",
     "description": "inbox tray",
     "aliases": [
       "inbox_tray"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📤",
+    "emojiChar": "📤",
+    "emoji": "\uD83D\uDCE4",
     "description": "outbox tray",
     "aliases": [
       "outbox_tray"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✉",
+    "emojiChar": "✉",
+    "emoji": "\u2709",
     "description": "envelope",
     "aliases": [
       "email",
@@ -3987,79 +4207,80 @@
     ]
   },
   {
-    "emoji": "📩",
+    "emojiChar": "📩",
+    "emoji": "\uD83D\uDCE9",
     "description": "envelope with downwards arrow above",
     "aliases": [
       "envelope_with_arrow"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📨",
+    "emojiChar": "📨",
+    "emoji": "\uD83D\uDCE8",
     "description": "incoming envelope",
     "aliases": [
       "incoming_envelope"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📯",
+    "emojiChar": "📯",
+    "emoji": "\uD83D\uDCEF",
     "description": "postal horn",
     "aliases": [
       "postal_horn"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📫",
+    "emojiChar": "📫",
+    "emoji": "\uD83D\uDCEB",
     "description": "closed mailbox with raised flag",
     "aliases": [
       "mailbox"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📪",
+    "emojiChar": "📪",
+    "emoji": "\uD83D\uDCEA",
     "description": "closed mailbox with lowered flag",
     "aliases": [
       "mailbox_closed"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📬",
+    "emojiChar": "📬",
+    "emoji": "\uD83D\uDCEC",
     "description": "open mailbox with raised flag",
     "aliases": [
       "mailbox_with_mail"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📭",
+    "emojiChar": "📭",
+    "emoji": "\uD83D\uDCED",
     "description": "open mailbox with lowered flag",
     "aliases": [
       "mailbox_with_no_mail"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📮",
+    "emojiChar": "📮",
+    "emoji": "\uD83D\uDCEE",
     "description": "postbox",
     "aliases": [
       "postbox"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📦",
+    "emojiChar": "📦",
+    "emoji": "\uD83D\uDCE6",
     "description": "package",
     "aliases": [
       "package"
@@ -4069,7 +4290,8 @@
     ]
   },
   {
-    "emoji": "📝",
+    "emojiChar": "📝",
+    "emoji": "\uD83D\uDCDD",
     "description": "memo",
     "aliases": [
       "memo",
@@ -4081,7 +4303,8 @@
     ]
   },
   {
-    "emoji": "📄",
+    "emojiChar": "📄",
+    "emoji": "\uD83D\uDCC4",
     "description": "page facing up",
     "aliases": [
       "page_facing_up"
@@ -4091,25 +4314,26 @@
     ]
   },
   {
-    "emoji": "📃",
+    "emojiChar": "📃",
+    "emoji": "\uD83D\uDCC3",
     "description": "page with curl",
     "aliases": [
       "page_with_curl"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📑",
+    "emojiChar": "📑",
+    "emoji": "\uD83D\uDCD1",
     "description": "bookmark tabs",
     "aliases": [
       "bookmark_tabs"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📊",
+    "emojiChar": "📊",
+    "emoji": "\uD83D\uDCCA",
     "description": "bar chart",
     "aliases": [
       "bar_chart"
@@ -4120,7 +4344,8 @@
     ]
   },
   {
-    "emoji": "📈",
+    "emojiChar": "📈",
+    "emoji": "\uD83D\uDCC8",
     "description": "chart with upwards trend",
     "aliases": [
       "chart_with_upwards_trend"
@@ -4131,7 +4356,8 @@
     ]
   },
   {
-    "emoji": "📉",
+    "emojiChar": "📉",
+    "emoji": "\uD83D\uDCC9",
     "description": "chart with downwards trend",
     "aliases": [
       "chart_with_downwards_trend"
@@ -4142,7 +4368,8 @@
     ]
   },
   {
-    "emoji": "📜",
+    "emojiChar": "📜",
+    "emoji": "\uD83D\uDCDC",
     "description": "scroll",
     "aliases": [
       "scroll"
@@ -4152,16 +4379,17 @@
     ]
   },
   {
-    "emoji": "📋",
+    "emojiChar": "📋",
+    "emoji": "\uD83D\uDCCB",
     "description": "clipboard",
     "aliases": [
       "clipboard"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📅",
+    "emojiChar": "📅",
+    "emoji": "\uD83D\uDCC5",
     "description": "calendar",
     "aliases": [
       "date"
@@ -4172,7 +4400,8 @@
     ]
   },
   {
-    "emoji": "📆",
+    "emojiChar": "📆",
+    "emoji": "\uD83D\uDCC6",
     "description": "tear-off calendar",
     "aliases": [
       "calendar"
@@ -4182,16 +4411,17 @@
     ]
   },
   {
-    "emoji": "📇",
+    "emojiChar": "📇",
+    "emoji": "\uD83D\uDCC7",
     "description": "card index",
     "aliases": [
       "card_index"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📁",
+    "emojiChar": "📁",
+    "emoji": "\uD83D\uDCC1",
     "description": "file folder",
     "aliases": [
       "file_folder"
@@ -4201,16 +4431,17 @@
     ]
   },
   {
-    "emoji": "📂",
+    "emojiChar": "📂",
+    "emoji": "\uD83D\uDCC2",
     "description": "open file folder",
     "aliases": [
       "open_file_folder"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✂",
+    "emojiChar": "✂",
+    "emoji": "\u2702",
     "description": "black scissors",
     "aliases": [
       "scissors"
@@ -4220,7 +4451,8 @@
     ]
   },
   {
-    "emoji": "📌",
+    "emojiChar": "📌",
+    "emoji": "\uD83D\uDCCC",
     "description": "pushpin",
     "aliases": [
       "pushpin"
@@ -4230,115 +4462,116 @@
     ]
   },
   {
-    "emoji": "📎",
+    "emojiChar": "📎",
+    "emoji": "\uD83D\uDCCE",
     "description": "paperclip",
     "aliases": [
       "paperclip"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✒",
+    "emojiChar": "✒",
+    "emoji": "\u2712",
     "description": "black nib",
     "aliases": [
       "black_nib"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✏",
+    "emojiChar": "✏",
+    "emoji": "\u270F",
     "description": "pencil",
     "aliases": [
       "pencil2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📏",
+    "emojiChar": "📏",
+    "emoji": "\uD83D\uDCCF",
     "description": "straight ruler",
     "aliases": [
       "straight_ruler"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📐",
+    "emojiChar": "📐",
+    "emoji": "\uD83D\uDCD0",
     "description": "triangular ruler",
     "aliases": [
       "triangular_ruler"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📕",
+    "emojiChar": "📕",
+    "emoji": "\uD83D\uDCD5",
     "description": "closed book",
     "aliases": [
       "closed_book"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📗",
+    "emojiChar": "📗",
+    "emoji": "\uD83D\uDCD7",
     "description": "green book",
     "aliases": [
       "green_book"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📘",
+    "emojiChar": "📘",
+    "emoji": "\uD83D\uDCD8",
     "description": "blue book",
     "aliases": [
       "blue_book"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📙",
+    "emojiChar": "📙",
+    "emoji": "\uD83D\uDCD9",
     "description": "orange book",
     "aliases": [
       "orange_book"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📓",
+    "emojiChar": "📓",
+    "emoji": "\uD83D\uDCD3",
     "description": "notebook",
     "aliases": [
       "notebook"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📔",
+    "emojiChar": "📔",
+    "emoji": "\uD83D\uDCD4",
     "description": "notebook with decorative cover",
     "aliases": [
       "notebook_with_decorative_cover"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📒",
+    "emojiChar": "📒",
+    "emoji": "\uD83D\uDCD2",
     "description": "ledger",
     "aliases": [
       "ledger"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📚",
+    "emojiChar": "📚",
+    "emoji": "\uD83D\uDCDA",
     "description": "books",
     "aliases": [
       "books"
@@ -4348,35 +4581,36 @@
     ]
   },
   {
-    "emoji": "📖",
+    "emojiChar": "📖",
+    "emoji": "\uD83D\uDCD6",
     "description": "open book",
     "aliases": [
       "book",
       "open_book"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔖",
+    "emojiChar": "🔖",
+    "emoji": "\uD83D\uDD16",
     "description": "bookmark",
     "aliases": [
       "bookmark"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📛",
+    "emojiChar": "📛",
+    "emoji": "\uD83D\uDCDB",
     "description": "name badge",
     "aliases": [
       "name_badge"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔬",
+    "emojiChar": "🔬",
+    "emoji": "\uD83D\uDD2C",
     "description": "microscope",
     "aliases": [
       "microscope"
@@ -4388,16 +4622,17 @@
     ]
   },
   {
-    "emoji": "🔭",
+    "emojiChar": "🔭",
+    "emoji": "\uD83D\uDD2D",
     "description": "telescope",
     "aliases": [
       "telescope"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📰",
+    "emojiChar": "📰",
+    "emoji": "\uD83D\uDCF0",
     "description": "newspaper",
     "aliases": [
       "newspaper"
@@ -4407,7 +4642,8 @@
     ]
   },
   {
-    "emoji": "🎨",
+    "emojiChar": "🎨",
+    "emoji": "\uD83C\uDFA8",
     "description": "artist palette",
     "aliases": [
       "art"
@@ -4418,7 +4654,8 @@
     ]
   },
   {
-    "emoji": "🎬",
+    "emojiChar": "🎬",
+    "emoji": "\uD83C\uDFAC",
     "description": "clapper board",
     "aliases": [
       "clapper"
@@ -4428,7 +4665,8 @@
     ]
   },
   {
-    "emoji": "🎤",
+    "emojiChar": "🎤",
+    "emoji": "\uD83C\uDFA4",
     "description": "microphone",
     "aliases": [
       "microphone"
@@ -4438,7 +4676,8 @@
     ]
   },
   {
-    "emoji": "🎧",
+    "emojiChar": "🎧",
+    "emoji": "\uD83C\uDFA7",
     "description": "headphone",
     "aliases": [
       "headphones"
@@ -4449,25 +4688,26 @@
     ]
   },
   {
-    "emoji": "🎼",
+    "emojiChar": "🎼",
+    "emoji": "\uD83C\uDFBC",
     "description": "musical score",
     "aliases": [
       "musical_score"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎵",
+    "emojiChar": "🎵",
+    "emoji": "\uD83C\uDFB5",
     "description": "musical note",
     "aliases": [
       "musical_note"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎶",
+    "emojiChar": "🎶",
+    "emoji": "\uD83C\uDFB6",
     "description": "multiple musical notes",
     "aliases": [
       "notes"
@@ -4477,7 +4717,8 @@
     ]
   },
   {
-    "emoji": "🎹",
+    "emojiChar": "🎹",
+    "emoji": "\uD83C\uDFB9",
     "description": "musical keyboard",
     "aliases": [
       "musical_keyboard"
@@ -4487,34 +4728,35 @@
     ]
   },
   {
-    "emoji": "🎻",
+    "emojiChar": "🎻",
+    "emoji": "\uD83C\uDFBB",
     "description": "violin",
     "aliases": [
       "violin"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎺",
+    "emojiChar": "🎺",
+    "emoji": "\uD83C\uDFBA",
     "description": "trumpet",
     "aliases": [
       "trumpet"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎷",
+    "emojiChar": "🎷",
+    "emoji": "\uD83C\uDFB7",
     "description": "saxophone",
     "aliases": [
       "saxophone"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎸",
+    "emojiChar": "🎸",
+    "emoji": "\uD83C\uDFB8",
     "description": "guitar",
     "aliases": [
       "guitar"
@@ -4524,7 +4766,8 @@
     ]
   },
   {
-    "emoji": "👾",
+    "emojiChar": "👾",
+    "emoji": "\uD83D\uDC7E",
     "description": "alien monster",
     "aliases": [
       "space_invader"
@@ -4535,7 +4778,8 @@
     ]
   },
   {
-    "emoji": "🎮",
+    "emojiChar": "🎮",
+    "emoji": "\uD83C\uDFAE",
     "description": "video game",
     "aliases": [
       "video_game"
@@ -4547,34 +4791,35 @@
     ]
   },
   {
-    "emoji": "🃏",
+    "emojiChar": "🃏",
+    "emoji": "\uD83C\uDCCF",
     "description": "playing card black joker",
     "aliases": [
       "black_joker"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎴",
+    "emojiChar": "🎴",
+    "emoji": "\uD83C\uDFB4",
     "description": "flower playing cards",
     "aliases": [
       "flower_playing_cards"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🀄",
+    "emojiChar": "🀄",
+    "emoji": "\uD83C\uDC04",
     "description": "mahjong tile red dragon",
     "aliases": [
       "mahjong"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎲",
+    "emojiChar": "🎲",
+    "emoji": "\uD83C\uDFB2",
     "description": "game die",
     "aliases": [
       "game_die"
@@ -4585,7 +4830,8 @@
     ]
   },
   {
-    "emoji": "🎯",
+    "emojiChar": "🎯",
+    "emoji": "\uD83C\uDFAF",
     "description": "direct hit",
     "aliases": [
       "dart"
@@ -4595,7 +4841,8 @@
     ]
   },
   {
-    "emoji": "🏈",
+    "emojiChar": "🏈",
+    "emoji": "\uD83C\uDFC8",
     "description": "american football",
     "aliases": [
       "football"
@@ -4605,7 +4852,8 @@
     ]
   },
   {
-    "emoji": "🏀",
+    "emojiChar": "🏀",
+    "emoji": "\uD83C\uDFC0",
     "description": "basketball and hoop",
     "aliases": [
       "basketball"
@@ -4615,7 +4863,8 @@
     ]
   },
   {
-    "emoji": "⚽",
+    "emojiChar": "⚽",
+    "emoji": "\u26BD",
     "description": "soccer ball",
     "aliases": [
       "soccer"
@@ -4625,7 +4874,8 @@
     ]
   },
   {
-    "emoji": "⚾",
+    "emojiChar": "⚾",
+    "emoji": "\u26BE",
     "description": "baseball",
     "aliases": [
       "baseball"
@@ -4635,7 +4885,8 @@
     ]
   },
   {
-    "emoji": "🎾",
+    "emojiChar": "🎾",
+    "emoji": "\uD83C\uDFBE",
     "description": "tennis racquet and ball",
     "aliases": [
       "tennis"
@@ -4645,7 +4896,8 @@
     ]
   },
   {
-    "emoji": "🎱",
+    "emojiChar": "🎱",
+    "emoji": "\uD83C\uDFB1",
     "description": "billiards",
     "aliases": [
       "8ball"
@@ -4656,54 +4908,55 @@
     ]
   },
   {
-    "emoji": "🏉",
+    "emojiChar": "🏉",
+    "emoji": "\uD83C\uDFC9",
     "description": "rugby football",
     "aliases": [
       "rugby_football"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎳",
+    "emojiChar": "🎳",
+    "emoji": "\uD83C\uDFB3",
     "description": "bowling",
     "aliases": [
       "bowling"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛳",
+    "emojiChar": "⛳",
+    "emoji": "\u26F3",
     "description": "flag in hole",
     "aliases": [
       "golf"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚵",
+    "emojiChar": "🚵",
+    "emoji": "\uD83D\uDEB5",
     "description": "mountain bicyclist",
     "supports_fitzpatrick": true,
     "aliases": [
       "mountain_bicyclist"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚴",
+    "emojiChar": "🚴",
+    "emoji": "\uD83D\uDEB4",
     "description": "bicyclist",
     "supports_fitzpatrick": true,
     "aliases": [
       "bicyclist"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏁",
+    "emojiChar": "🏁",
+    "emoji": "\uD83C\uDFC1",
     "description": "chequered flag",
     "aliases": [
       "checkered_flag"
@@ -4714,17 +4967,18 @@
     ]
   },
   {
-    "emoji": "🏇",
+    "emojiChar": "🏇",
+    "emoji": "\uD83C\uDFC7",
     "description": "horse racing",
     "supports_fitzpatrick": true,
     "aliases": [
       "horse_racing"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏆",
+    "emojiChar": "🏆",
+    "emoji": "\uD83C\uDFC6",
     "description": "trophy",
     "aliases": [
       "trophy"
@@ -4736,55 +4990,56 @@
     ]
   },
   {
-    "emoji": "🎿",
+    "emojiChar": "🎿",
+    "emoji": "\uD83C\uDFBF",
     "description": "ski and ski boot",
     "aliases": [
       "ski"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏂",
+    "emojiChar": "🏂",
+    "emoji": "\uD83C\uDFC2",
     "description": "snowboarder",
     "supports_fitzpatrick": true,
     "aliases": [
       "snowboarder"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏊",
+    "emojiChar": "🏊",
+    "emoji": "\uD83C\uDFCA",
     "description": "swimmer",
     "supports_fitzpatrick": true,
     "aliases": [
       "swimmer"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏄",
+    "emojiChar": "🏄",
+    "emoji": "\uD83C\uDFC4",
     "description": "surfer",
     "supports_fitzpatrick": true,
     "aliases": [
       "surfer"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎣",
+    "emojiChar": "🎣",
+    "emoji": "\uD83C\uDFA3",
     "description": "fishing pole and fish",
     "aliases": [
       "fishing_pole_and_fish"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "☕",
+    "emojiChar": "☕",
+    "emoji": "\u2615",
     "description": "hot beverage",
     "aliases": [
       "coffee"
@@ -4795,7 +5050,8 @@
     ]
   },
   {
-    "emoji": "🍵",
+    "emojiChar": "🍵",
+    "emoji": "\uD83C\uDF75",
     "description": "teacup without handle",
     "aliases": [
       "tea"
@@ -4806,16 +5062,17 @@
     ]
   },
   {
-    "emoji": "🍶",
+    "emojiChar": "🍶",
+    "emoji": "\uD83C\uDF76",
     "description": "sake bottle and cup",
     "aliases": [
       "sake"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍼",
+    "emojiChar": "🍼",
+    "emoji": "\uD83C\uDF7C",
     "description": "baby bottle",
     "aliases": [
       "baby_bottle"
@@ -4825,7 +5082,8 @@
     ]
   },
   {
-    "emoji": "🍺",
+    "emojiChar": "🍺",
+    "emoji": "\uD83C\uDF7A",
     "description": "beer mug",
     "aliases": [
       "beer"
@@ -4835,7 +5093,8 @@
     ]
   },
   {
-    "emoji": "🍻",
+    "emojiChar": "🍻",
+    "emoji": "\uD83C\uDF7B",
     "description": "clinking beer mugs",
     "aliases": [
       "beers"
@@ -4845,7 +5104,8 @@
     ]
   },
   {
-    "emoji": "🍸",
+    "emojiChar": "🍸",
+    "emoji": "\uD83C\uDF78",
     "description": "cocktail glass",
     "aliases": [
       "cocktail"
@@ -4855,7 +5115,8 @@
     ]
   },
   {
-    "emoji": "🍹",
+    "emojiChar": "🍹",
+    "emoji": "\uD83C\uDF79",
     "description": "tropical drink",
     "aliases": [
       "tropical_drink"
@@ -4866,16 +5127,17 @@
     ]
   },
   {
-    "emoji": "🍷",
+    "emojiChar": "🍷",
+    "emoji": "\uD83C\uDF77",
     "description": "wine glass",
     "aliases": [
       "wine_glass"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍴",
+    "emojiChar": "🍴",
+    "emoji": "\uD83C\uDF74",
     "description": "fork and knife",
     "aliases": [
       "fork_and_knife"
@@ -4885,16 +5147,17 @@
     ]
   },
   {
-    "emoji": "🍕",
+    "emojiChar": "🍕",
+    "emoji": "\uD83C\uDF55",
     "description": "slice of pizza",
     "aliases": [
       "pizza"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍔",
+    "emojiChar": "🍔",
+    "emoji": "\uD83C\uDF54",
     "description": "hamburger",
     "aliases": [
       "hamburger"
@@ -4904,16 +5167,17 @@
     ]
   },
   {
-    "emoji": "🍟",
+    "emojiChar": "🍟",
+    "emoji": "\uD83C\uDF5F",
     "description": "french fries",
     "aliases": [
       "fries"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍗",
+    "emojiChar": "🍗",
+    "emoji": "\uD83C\uDF57",
     "description": "poultry leg",
     "aliases": [
       "poultry_leg"
@@ -4924,16 +5188,17 @@
     ]
   },
   {
-    "emoji": "🍖",
+    "emojiChar": "🍖",
+    "emoji": "\uD83C\uDF56",
     "description": "meat on bone",
     "aliases": [
       "meat_on_bone"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍝",
+    "emojiChar": "🍝",
+    "emoji": "\uD83C\uDF5D",
     "description": "spaghetti",
     "aliases": [
       "spaghetti"
@@ -4943,16 +5208,17 @@
     ]
   },
   {
-    "emoji": "🍛",
+    "emojiChar": "🍛",
+    "emoji": "\uD83C\uDF5B",
     "description": "curry and rice",
     "aliases": [
       "curry"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍤",
+    "emojiChar": "🍤",
+    "emoji": "\uD83C\uDF64",
     "description": "fried shrimp",
     "aliases": [
       "fried_shrimp"
@@ -4962,61 +5228,62 @@
     ]
   },
   {
-    "emoji": "🍱",
+    "emojiChar": "🍱",
+    "emoji": "\uD83C\uDF71",
     "description": "bento box",
     "aliases": [
       "bento"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍣",
+    "emojiChar": "🍣",
+    "emoji": "\uD83C\uDF63",
     "description": "sushi",
     "aliases": [
       "sushi"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍥",
+    "emojiChar": "🍥",
+    "emoji": "\uD83C\uDF65",
     "description": "fish cake with swirl design",
     "aliases": [
       "fish_cake"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍙",
+    "emojiChar": "🍙",
+    "emoji": "\uD83C\uDF59",
     "description": "rice ball",
     "aliases": [
       "rice_ball"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍘",
+    "emojiChar": "🍘",
+    "emoji": "\uD83C\uDF58",
     "description": "rice cracker",
     "aliases": [
       "rice_cracker"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍚",
+    "emojiChar": "🍚",
+    "emoji": "\uD83C\uDF5A",
     "description": "cooked rice",
     "aliases": [
       "rice"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍜",
+    "emojiChar": "🍜",
+    "emoji": "\uD83C\uDF5C",
     "description": "steaming bowl",
     "aliases": [
       "ramen"
@@ -5026,34 +5293,35 @@
     ]
   },
   {
-    "emoji": "🍲",
+    "emojiChar": "🍲",
+    "emoji": "\uD83C\uDF72",
     "description": "pot of food",
     "aliases": [
       "stew"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍢",
+    "emojiChar": "🍢",
+    "emoji": "\uD83C\uDF62",
     "description": "oden",
     "aliases": [
       "oden"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍡",
+    "emojiChar": "🍡",
+    "emoji": "\uD83C\uDF61",
     "description": "dango",
     "aliases": [
       "dango"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍳",
+    "emojiChar": "🍳",
+    "emoji": "\uD83C\uDF73",
     "description": "cooking",
     "aliases": [
       "cooking"
@@ -5063,7 +5331,8 @@
     ]
   },
   {
-    "emoji": "🍞",
+    "emojiChar": "🍞",
+    "emoji": "\uD83C\uDF5E",
     "description": "bread",
     "aliases": [
       "bread"
@@ -5073,52 +5342,53 @@
     ]
   },
   {
-    "emoji": "🍩",
+    "emojiChar": "🍩",
+    "emoji": "\uD83C\uDF69",
     "description": "doughnut",
     "aliases": [
       "doughnut"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍮",
+    "emojiChar": "🍮",
+    "emoji": "\uD83C\uDF6E",
     "description": "custard",
     "aliases": [
       "custard"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍦",
+    "emojiChar": "🍦",
+    "emoji": "\uD83C\uDF66",
     "description": "soft ice cream",
     "aliases": [
       "icecream"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍨",
+    "emojiChar": "🍨",
+    "emoji": "\uD83C\uDF68",
     "description": "ice cream",
     "aliases": [
       "ice_cream"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍧",
+    "emojiChar": "🍧",
+    "emoji": "\uD83C\uDF67",
     "description": "shaved ice",
     "aliases": [
       "shaved_ice"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎂",
+    "emojiChar": "🎂",
+    "emoji": "\uD83C\uDF82",
     "description": "birthday cake",
     "aliases": [
       "birthday"
@@ -5128,7 +5398,8 @@
     ]
   },
   {
-    "emoji": "🍰",
+    "emojiChar": "🍰",
+    "emoji": "\uD83C\uDF70",
     "description": "shortcake",
     "aliases": [
       "cake"
@@ -5138,25 +5409,26 @@
     ]
   },
   {
-    "emoji": "🍪",
+    "emojiChar": "🍪",
+    "emoji": "\uD83C\uDF6A",
     "description": "cookie",
     "aliases": [
       "cookie"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍫",
+    "emojiChar": "🍫",
+    "emoji": "\uD83C\uDF6B",
     "description": "chocolate bar",
     "aliases": [
       "chocolate_bar"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍬",
+    "emojiChar": "🍬",
+    "emoji": "\uD83C\uDF6C",
     "description": "candy",
     "aliases": [
       "candy"
@@ -5166,34 +5438,35 @@
     ]
   },
   {
-    "emoji": "🍭",
+    "emojiChar": "🍭",
+    "emoji": "\uD83C\uDF6D",
     "description": "lollipop",
     "aliases": [
       "lollipop"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍯",
+    "emojiChar": "🍯",
+    "emoji": "\uD83C\uDF6F",
     "description": "honey pot",
     "aliases": [
       "honey_pot"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍎",
+    "emojiChar": "🍎",
+    "emoji": "\uD83C\uDF4E",
     "description": "red apple",
     "aliases": [
       "apple"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍏",
+    "emojiChar": "🍏",
+    "emoji": "\uD83C\uDF4F",
     "description": "green apple",
     "aliases": [
       "green_apple"
@@ -5203,25 +5476,26 @@
     ]
   },
   {
-    "emoji": "🍊",
+    "emojiChar": "🍊",
+    "emoji": "\uD83C\uDF4A",
     "description": "tangerine",
     "aliases": [
       "tangerine"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍋",
+    "emojiChar": "🍋",
+    "emoji": "\uD83C\uDF4B",
     "description": "lemon",
     "aliases": [
       "lemon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍒",
+    "emojiChar": "🍒",
+    "emoji": "\uD83C\uDF52",
     "description": "cherries",
     "aliases": [
       "cherries"
@@ -5231,25 +5505,26 @@
     ]
   },
   {
-    "emoji": "🍇",
+    "emojiChar": "🍇",
+    "emoji": "\uD83C\uDF47",
     "description": "grapes",
     "aliases": [
       "grapes"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍉",
+    "emojiChar": "🍉",
+    "emoji": "\uD83C\uDF49",
     "description": "watermelon",
     "aliases": [
       "watermelon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍓",
+    "emojiChar": "🍓",
+    "emoji": "\uD83C\uDF53",
     "description": "strawberry",
     "aliases": [
       "strawberry"
@@ -5259,25 +5534,26 @@
     ]
   },
   {
-    "emoji": "🍑",
+    "emojiChar": "🍑",
+    "emoji": "\uD83C\uDF51",
     "description": "peach",
     "aliases": [
       "peach"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍈",
+    "emojiChar": "🍈",
+    "emoji": "\uD83C\uDF48",
     "description": "melon",
     "aliases": [
       "melon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍌",
+    "emojiChar": "🍌",
+    "emoji": "\uD83C\uDF4C",
     "description": "banana",
     "aliases": [
       "banana"
@@ -5287,34 +5563,35 @@
     ]
   },
   {
-    "emoji": "🍐",
+    "emojiChar": "🍐",
+    "emoji": "\uD83C\uDF50",
     "description": "pear",
     "aliases": [
       "pear"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍍",
+    "emojiChar": "🍍",
+    "emoji": "\uD83C\uDF4D",
     "description": "pineapple",
     "aliases": [
       "pineapple"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍠",
+    "emojiChar": "🍠",
+    "emoji": "\uD83C\uDF60",
     "description": "roasted sweet potato",
     "aliases": [
       "sweet_potato"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🍆",
+    "emojiChar": "🍆",
+    "emoji": "\uD83C\uDF46",
     "description": "aubergine",
     "aliases": [
       "eggplant"
@@ -5324,115 +5601,116 @@
     ]
   },
   {
-    "emoji": "🍅",
+    "emojiChar": "🍅",
+    "emoji": "\uD83C\uDF45",
     "description": "tomato",
     "aliases": [
       "tomato"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌽",
+    "emojiChar": "🌽",
+    "emoji": "\uD83C\uDF3D",
     "description": "ear of maize",
     "aliases": [
       "corn"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏠",
+    "emojiChar": "🏠",
+    "emoji": "\uD83C\uDFE0",
     "description": "house building",
     "aliases": [
       "house"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏡",
+    "emojiChar": "🏡",
+    "emoji": "\uD83C\uDFE1",
     "description": "house with garden",
     "aliases": [
       "house_with_garden"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏫",
+    "emojiChar": "🏫",
+    "emoji": "\uD83C\uDFEB",
     "description": "school",
     "aliases": [
       "school"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏢",
+    "emojiChar": "🏢",
+    "emoji": "\uD83C\uDFE2",
     "description": "office building",
     "aliases": [
       "office"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏣",
+    "emojiChar": "🏣",
+    "emoji": "\uD83C\uDFE3",
     "description": "japanese post office",
     "aliases": [
       "post_office"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏥",
+    "emojiChar": "🏥",
+    "emoji": "\uD83C\uDFE5",
     "description": "hospital",
     "aliases": [
       "hospital"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏦",
+    "emojiChar": "🏦",
+    "emoji": "\uD83C\uDFE6",
     "description": "bank",
     "aliases": [
       "bank"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏪",
+    "emojiChar": "🏪",
+    "emoji": "\uD83C\uDFEA",
     "description": "convenience store",
     "aliases": [
       "convenience_store"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏩",
+    "emojiChar": "🏩",
+    "emoji": "\uD83C\uDFE9",
     "description": "love hotel",
     "aliases": [
       "love_hotel"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏨",
+    "emojiChar": "🏨",
+    "emoji": "\uD83C\uDFE8",
     "description": "hotel",
     "aliases": [
       "hotel"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💒",
+    "emojiChar": "💒",
+    "emoji": "\uD83D\uDC92",
     "description": "wedding",
     "aliases": [
       "wedding"
@@ -5442,70 +5720,71 @@
     ]
   },
   {
-    "emoji": "⛪",
+    "emojiChar": "⛪",
+    "emoji": "\u26EA",
     "description": "church",
     "aliases": [
       "church"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏬",
+    "emojiChar": "🏬",
+    "emoji": "\uD83C\uDFEC",
     "description": "department store",
     "aliases": [
       "department_store"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏤",
+    "emojiChar": "🏤",
+    "emoji": "\uD83C\uDFE4",
     "description": "european post office",
     "aliases": [
       "european_post_office"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌇",
+    "emojiChar": "🌇",
+    "emoji": "\uD83C\uDF07",
     "description": "sunset over buildings",
     "aliases": [
       "city_sunrise"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌆",
+    "emojiChar": "🌆",
+    "emoji": "\uD83C\uDF06",
     "description": "cityscape at dusk",
     "aliases": [
       "city_sunset"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏯",
+    "emojiChar": "🏯",
+    "emoji": "\uD83C\uDFEF",
     "description": "japanese castle",
     "aliases": [
       "japanese_castle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏰",
+    "emojiChar": "🏰",
+    "emoji": "\uD83C\uDFF0",
     "description": "european castle",
     "aliases": [
       "european_castle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛺",
+    "emojiChar": "⛺",
+    "emoji": "\u26FA",
     "description": "tent",
     "aliases": [
       "tent"
@@ -5515,143 +5794,144 @@
     ]
   },
   {
-    "emoji": "🏭",
+    "emojiChar": "🏭",
+    "emoji": "\uD83C\uDFED",
     "description": "factory",
     "aliases": [
       "factory"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🗼",
+    "emojiChar": "🗼",
+    "emoji": "\uD83D\uDDFC",
     "description": "tokyo tower",
     "aliases": [
       "tokyo_tower"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🗾",
+    "emojiChar": "🗾",
+    "emoji": "\uD83D\uDDFE",
     "description": "silhouette of japan",
     "aliases": [
       "japan"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🗻",
+    "emojiChar": "🗻",
+    "emoji": "\uD83D\uDDFB",
     "description": "mount fuji",
     "aliases": [
       "mount_fuji"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌄",
+    "emojiChar": "🌄",
+    "emoji": "\uD83C\uDF04",
     "description": "sunrise over mountains",
     "aliases": [
       "sunrise_over_mountains"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌅",
+    "emojiChar": "🌅",
+    "emoji": "\uD83C\uDF05",
     "description": "sunrise",
     "aliases": [
       "sunrise"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌃",
+    "emojiChar": "🌃",
+    "emoji": "\uD83C\uDF03",
     "description": "night with stars",
     "aliases": [
       "night_with_stars"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🗽",
+    "emojiChar": "🗽",
+    "emoji": "\uD83D\uDDFD",
     "description": "statue of liberty",
     "aliases": [
       "statue_of_liberty"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🌉",
+    "emojiChar": "🌉",
+    "emoji": "\uD83C\uDF09",
     "description": "bridge at night",
     "aliases": [
       "bridge_at_night"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎠",
+    "emojiChar": "🎠",
+    "emoji": "\uD83C\uDFA0",
     "description": "carousel horse",
     "aliases": [
       "carousel_horse"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎡",
+    "emojiChar": "🎡",
+    "emoji": "\uD83C\uDFA1",
     "description": "ferris wheel",
     "aliases": [
       "ferris_wheel"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛲",
+    "emojiChar": "⛲",
+    "emoji": "\u26F2",
     "description": "fountain",
     "aliases": [
       "fountain"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎢",
+    "emojiChar": "🎢",
+    "emoji": "\uD83C\uDFA2",
     "description": "roller coaster",
     "aliases": [
       "roller_coaster"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚢",
+    "emojiChar": "🚢",
+    "emoji": "\uD83D\uDEA2",
     "description": "ship",
     "aliases": [
       "ship"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛵",
+    "emojiChar": "⛵",
+    "emoji": "\u26F5",
     "description": "sailboat",
     "aliases": [
       "boat",
       "sailboat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚤",
+    "emojiChar": "🚤",
+    "emoji": "\uD83D\uDEA4",
     "description": "speedboat",
     "aliases": [
       "speedboat"
@@ -5661,17 +5941,18 @@
     ]
   },
   {
-    "emoji": "🚣",
+    "emojiChar": "🚣",
+    "emoji": "\uD83D\uDEA3",
     "description": "rowboat",
     "supports_fitzpatrick": true,
     "aliases": [
       "rowboat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⚓",
+    "emojiChar": "⚓",
+    "emoji": "\u2693",
     "description": "anchor",
     "aliases": [
       "anchor"
@@ -5681,7 +5962,8 @@
     ]
   },
   {
-    "emoji": "🚀",
+    "emojiChar": "🚀",
+    "emoji": "\uD83D\uDE80",
     "description": "rocket",
     "aliases": [
       "rocket"
@@ -5692,7 +5974,8 @@
     ]
   },
   {
-    "emoji": "✈",
+    "emojiChar": "✈",
+    "emoji": "\u2708",
     "description": "airplane",
     "aliases": [
       "airplane"
@@ -5702,25 +5985,26 @@
     ]
   },
   {
-    "emoji": "💺",
+    "emojiChar": "💺",
+    "emoji": "\uD83D\uDCBA",
     "description": "seat",
     "aliases": [
       "seat"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚁",
+    "emojiChar": "🚁",
+    "emoji": "\uD83D\uDE81",
     "description": "helicopter",
     "aliases": [
       "helicopter"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚂",
+    "emojiChar": "🚂",
+    "emoji": "\uD83D\uDE82",
     "description": "steam locomotive",
     "aliases": [
       "steam_locomotive"
@@ -5730,43 +6014,44 @@
     ]
   },
   {
-    "emoji": "🚊",
+    "emojiChar": "🚊",
+    "emoji": "\uD83D\uDE8A",
     "description": "tram",
     "aliases": [
       "tram"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚉",
+    "emojiChar": "🚉",
+    "emoji": "\uD83D\uDE89",
     "description": "station",
     "aliases": [
       "station"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚞",
+    "emojiChar": "🚞",
+    "emoji": "\uD83D\uDE9E",
     "description": "mountain railway",
     "aliases": [
       "mountain_railway"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚆",
+    "emojiChar": "🚆",
+    "emoji": "\uD83D\uDE86",
     "description": "train",
     "aliases": [
       "train2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚄",
+    "emojiChar": "🚄",
+    "emoji": "\uD83D\uDE84",
     "description": "high-speed train",
     "aliases": [
       "bullettrain_side"
@@ -5776,7 +6061,8 @@
     ]
   },
   {
-    "emoji": "🚅",
+    "emojiChar": "🚅",
+    "emoji": "\uD83D\uDE85",
     "description": "high-speed train with bullet nose",
     "aliases": [
       "bullettrain_front"
@@ -5786,143 +6072,144 @@
     ]
   },
   {
-    "emoji": "🚈",
+    "emojiChar": "🚈",
+    "emoji": "\uD83D\uDE88",
     "description": "light rail",
     "aliases": [
       "light_rail"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚇",
+    "emojiChar": "🚇",
+    "emoji": "\uD83D\uDE87",
     "description": "metro",
     "aliases": [
       "metro"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚝",
+    "emojiChar": "🚝",
+    "emoji": "\uD83D\uDE9D",
     "description": "monorail",
     "aliases": [
       "monorail"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚋",
+    "emojiChar": "🚋",
+    "emoji": "\uD83D\uDE8B",
     "description": "tram car",
     "aliases": [
       "train"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚃",
+    "emojiChar": "🚃",
+    "emoji": "\uD83D\uDE83",
     "description": "railway car",
     "aliases": [
       "railway_car"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚎",
+    "emojiChar": "🚎",
+    "emoji": "\uD83D\uDE8E",
     "description": "trolleybus",
     "aliases": [
       "trolleybus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚌",
+    "emojiChar": "🚌",
+    "emoji": "\uD83D\uDE8C",
     "description": "bus",
     "aliases": [
       "bus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚍",
+    "emojiChar": "🚍",
+    "emoji": "\uD83D\uDE8D",
     "description": "oncoming bus",
     "aliases": [
       "oncoming_bus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚙",
+    "emojiChar": "🚙",
+    "emoji": "\uD83D\uDE99",
     "description": "recreational vehicle",
     "aliases": [
       "blue_car"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚘",
+    "emojiChar": "🚘",
+    "emoji": "\uD83D\uDE98",
     "description": "oncoming automobile",
     "aliases": [
       "oncoming_automobile"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚗",
+    "emojiChar": "🚗",
+    "emoji": "\uD83D\uDE97",
     "description": "automobile",
     "aliases": [
       "car",
       "red_car"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚕",
+    "emojiChar": "🚕",
+    "emoji": "\uD83D\uDE95",
     "description": "taxi",
     "aliases": [
       "taxi"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚖",
+    "emojiChar": "🚖",
+    "emoji": "\uD83D\uDE96",
     "description": "oncoming taxi",
     "aliases": [
       "oncoming_taxi"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚛",
+    "emojiChar": "🚛",
+    "emoji": "\uD83D\uDE9B",
     "description": "articulated lorry",
     "aliases": [
       "articulated_lorry"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚚",
+    "emojiChar": "🚚",
+    "emoji": "\uD83D\uDE9A",
     "description": "delivery truck",
     "aliases": [
       "truck"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚨",
+    "emojiChar": "🚨",
+    "emoji": "\uD83D\uDEA8",
     "description": "police cars revolving light",
     "aliases": [
       "rotating_light"
@@ -5933,52 +6220,53 @@
     ]
   },
   {
-    "emoji": "🚓",
+    "emojiChar": "🚓",
+    "emoji": "\uD83D\uDE93",
     "description": "police car",
     "aliases": [
       "police_car"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚔",
+    "emojiChar": "🚔",
+    "emoji": "\uD83D\uDE94",
     "description": "oncoming police car",
     "aliases": [
       "oncoming_police_car"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚒",
+    "emojiChar": "🚒",
+    "emoji": "\uD83D\uDE92",
     "description": "fire engine",
     "aliases": [
       "fire_engine"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚑",
+    "emojiChar": "🚑",
+    "emoji": "\uD83D\uDE91",
     "description": "ambulance",
     "aliases": [
       "ambulance"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚐",
+    "emojiChar": "🚐",
+    "emoji": "\uD83D\uDE90",
     "description": "minibus",
     "aliases": [
       "minibus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚲",
+    "emojiChar": "🚲",
+    "emoji": "\uD83D\uDEB2",
     "description": "bicycle",
     "aliases": [
       "bike"
@@ -5988,70 +6276,71 @@
     ]
   },
   {
-    "emoji": "🚡",
+    "emojiChar": "🚡",
+    "emoji": "\uD83D\uDEA1",
     "description": "aerial tramway",
     "aliases": [
       "aerial_tramway"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚟",
+    "emojiChar": "🚟",
+    "emoji": "\uD83D\uDE9F",
     "description": "suspension railway",
     "aliases": [
       "suspension_railway"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚠",
+    "emojiChar": "🚠",
+    "emoji": "\uD83D\uDEA0",
     "description": "mountain cableway",
     "aliases": [
       "mountain_cableway"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚜",
+    "emojiChar": "🚜",
+    "emoji": "\uD83D\uDE9C",
     "description": "tractor",
     "aliases": [
       "tractor"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💈",
+    "emojiChar": "💈",
+    "emoji": "\uD83D\uDC88",
     "description": "barber pole",
     "aliases": [
       "barber"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚏",
+    "emojiChar": "🚏",
+    "emoji": "\uD83D\uDE8F",
     "description": "bus stop",
     "aliases": [
       "busstop"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎫",
+    "emojiChar": "🎫",
+    "emoji": "\uD83C\uDFAB",
     "description": "ticket",
     "aliases": [
       "ticket"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚦",
+    "emojiChar": "🚦",
+    "emoji": "\uD83D\uDEA6",
     "description": "vertical traffic light",
     "aliases": [
       "vertical_traffic_light"
@@ -6061,16 +6350,17 @@
     ]
   },
   {
-    "emoji": "🚥",
+    "emojiChar": "🚥",
+    "emoji": "\uD83D\uDEA5",
     "description": "horizontal traffic light",
     "aliases": [
       "traffic_light"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⚠",
+    "emojiChar": "⚠",
+    "emoji": "\u26A0",
     "description": "warning sign",
     "aliases": [
       "warning"
@@ -6080,7 +6370,8 @@
     ]
   },
   {
-    "emoji": "🚧",
+    "emojiChar": "🚧",
+    "emoji": "\uD83D\uDEA7",
     "description": "construction sign",
     "aliases": [
       "construction"
@@ -6090,53 +6381,54 @@
     ]
   },
   {
-    "emoji": "🔰",
+    "emojiChar": "🔰",
+    "emoji": "\uD83D\uDD30",
     "description": "japanese symbol for beginner",
     "aliases": [
       "beginner"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛽",
+    "emojiChar": "⛽",
+    "emoji": "\u26FD",
     "description": "fuel pump",
     "aliases": [
       "fuelpump"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏮",
+    "emojiChar": "🏮",
+    "emoji": "\uD83C\uDFEE",
     "description": "izakaya lantern",
     "aliases": [
       "izakaya_lantern",
       "lantern"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎰",
+    "emojiChar": "🎰",
+    "emoji": "\uD83C\uDFB0",
     "description": "slot machine",
     "aliases": [
       "slot_machine"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♨",
+    "emojiChar": "♨",
+    "emoji": "\u2668",
     "description": "hot springs",
     "aliases": [
       "hotsprings"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🗿",
+    "emojiChar": "🗿",
+    "emoji": "\uD83D\uDDFF",
     "description": "moyai",
     "aliases": [
       "moyai"
@@ -6146,16 +6438,17 @@
     ]
   },
   {
-    "emoji": "🎪",
+    "emojiChar": "🎪",
+    "emoji": "\uD83C\uDFAA",
     "description": "circus tent",
     "aliases": [
       "circus_tent"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🎭",
+    "emojiChar": "🎭",
+    "emoji": "\uD83C\uDFAD",
     "description": "performing arts",
     "aliases": [
       "performing_arts"
@@ -6166,7 +6459,8 @@
     ]
   },
   {
-    "emoji": "📍",
+    "emojiChar": "📍",
+    "emoji": "\uD83D\uDCCD",
     "description": "round pushpin",
     "aliases": [
       "round_pushpin"
@@ -6176,115 +6470,116 @@
     ]
   },
   {
-    "emoji": "🚩",
+    "emojiChar": "🚩",
+    "emoji": "\uD83D\uDEA9",
     "description": "triangular flag on post",
     "aliases": [
       "triangular_flag_on_post"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "1⃣",
+    "emojiChar": "1⃣",
+    "emoji": "1\u20E3",
     "description": "digit one + combining enclosing keycap",
     "aliases": [
       "one"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "2⃣",
+    "emojiChar": "2⃣",
+    "emoji": "2\u20E3",
     "description": "digit two + combining enclosing keycap",
     "aliases": [
       "two"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "3⃣",
+    "emojiChar": "3⃣",
+    "emoji": "3\u20E3",
     "description": "digit three + combining enclosing keycap",
     "aliases": [
       "three"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "4⃣",
+    "emojiChar": "4⃣",
+    "emoji": "4\u20E3",
     "description": "digit four + combining enclosing keycap",
     "aliases": [
       "four"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "5⃣",
+    "emojiChar": "5⃣",
+    "emoji": "5\u20E3",
     "description": "digit five + combining enclosing keycap",
     "aliases": [
       "five"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "6⃣",
+    "emojiChar": "6⃣",
+    "emoji": "6\u20E3",
     "description": "digit six + combining enclosing keycap",
     "aliases": [
       "six"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "7⃣",
+    "emojiChar": "7⃣",
+    "emoji": "7\u20E3",
     "description": "digit seven + combining enclosing keycap",
     "aliases": [
       "seven"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "8⃣",
+    "emojiChar": "8⃣",
+    "emoji": "8\u20E3",
     "description": "digit eight + combining enclosing keycap",
     "aliases": [
       "eight"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "9⃣",
+    "emojiChar": "9⃣",
+    "emoji": "9\u20E3",
     "description": "digit nine + combining enclosing keycap",
     "aliases": [
       "nine"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "0⃣",
+    "emojiChar": "0⃣",
+    "emoji": "0\u20E3",
     "description": "digit zero + combining enclosing keycap",
     "aliases": [
       "zero"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔟",
+    "emojiChar": "🔟",
+    "emoji": "\uD83D\uDD1F",
     "description": "keycap ten",
     "aliases": [
       "keycap_ten"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔢",
+    "emojiChar": "🔢",
+    "emoji": "\uD83D\uDD22",
     "description": "input symbol for numbers",
     "aliases": [
       "1234"
@@ -6294,7 +6589,8 @@
     ]
   },
   {
-    "emoji": "#⃣",
+    "emojiChar": "#⃣",
+    "emoji": "#\u20E3",
     "description": "number sign + combining enclosing keycap",
     "aliases": [
       "hash"
@@ -6304,52 +6600,53 @@
     ]
   },
   {
-    "emoji": "🔣",
+    "emojiChar": "🔣",
+    "emoji": "\uD83D\uDD23",
     "description": "input symbol for symbols",
     "aliases": [
       "symbols"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⬆",
+    "emojiChar": "⬆",
+    "emoji": "\u2B06",
     "description": "upwards black arrow",
     "aliases": [
       "arrow_up"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⬇",
+    "emojiChar": "⬇",
+    "emoji": "\u2B07",
     "description": "downwards black arrow",
     "aliases": [
       "arrow_down"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⬅",
+    "emojiChar": "⬅",
+    "emoji": "\u2B05",
     "description": "leftwards black arrow",
     "aliases": [
       "arrow_left"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "➡",
+    "emojiChar": "➡",
+    "emoji": "\u27A1",
     "description": "black rightwards arrow",
     "aliases": [
       "arrow_right"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔠",
+    "emojiChar": "🔠",
+    "emoji": "\uD83D\uDD20",
     "description": "input symbol for latin capital letters",
     "aliases": [
       "capital_abcd"
@@ -6359,16 +6656,17 @@
     ]
   },
   {
-    "emoji": "🔡",
+    "emojiChar": "🔡",
+    "emoji": "\uD83D\uDD21",
     "description": "input symbol for latin small letters",
     "aliases": [
       "abcd"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔤",
+    "emojiChar": "🔤",
+    "emoji": "\uD83D\uDD24",
     "description": "input symbol for latin letters",
     "aliases": [
       "abc"
@@ -6378,61 +6676,62 @@
     ]
   },
   {
-    "emoji": "↗",
+    "emojiChar": "↗",
+    "emoji": "\u2197",
     "description": "north east arrow",
     "aliases": [
       "arrow_upper_right"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "↖",
+    "emojiChar": "↖",
+    "emoji": "\u2196",
     "description": "north west arrow",
     "aliases": [
       "arrow_upper_left"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "↘",
+    "emojiChar": "↘",
+    "emoji": "\u2198",
     "description": "south east arrow",
     "aliases": [
       "arrow_lower_right"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "↙",
+    "emojiChar": "↙",
+    "emoji": "\u2199",
     "description": "south west arrow",
     "aliases": [
       "arrow_lower_left"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "↔",
+    "emojiChar": "↔",
+    "emoji": "\u2194",
     "description": "left right arrow",
     "aliases": [
       "left_right_arrow"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "↕",
+    "emojiChar": "↕",
+    "emoji": "\u2195",
     "description": "up down arrow",
     "aliases": [
       "arrow_up_down"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔄",
+    "emojiChar": "🔄",
+    "emoji": "\uD83D\uDD04",
     "description": "anticlockwise downwards and upwards open circle arrows",
     "aliases": [
       "arrows_counterclockwise"
@@ -6442,43 +6741,44 @@
     ]
   },
   {
-    "emoji": "◀",
+    "emojiChar": "◀",
+    "emoji": "\u25C0",
     "description": "black left-pointing triangle",
     "aliases": [
       "arrow_backward"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "▶",
+    "emojiChar": "▶",
+    "emoji": "\u25B6",
     "description": "black right-pointing triangle",
     "aliases": [
       "arrow_forward"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔼",
+    "emojiChar": "🔼",
+    "emoji": "\uD83D\uDD3C",
     "description": "up-pointing small red triangle",
     "aliases": [
       "arrow_up_small"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔽",
+    "emojiChar": "🔽",
+    "emoji": "\uD83D\uDD3D",
     "description": "down-pointing small red triangle",
     "aliases": [
       "arrow_down_small"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "↩",
+    "emojiChar": "↩",
+    "emoji": "\u21A9",
     "description": "leftwards arrow with hook",
     "aliases": [
       "leftwards_arrow_with_hook"
@@ -6488,79 +6788,80 @@
     ]
   },
   {
-    "emoji": "↪",
+    "emojiChar": "↪",
+    "emoji": "\u21AA",
     "description": "rightwards arrow with hook",
     "aliases": [
       "arrow_right_hook"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "ℹ",
+    "emojiChar": "ℹ",
+    "emoji": "\u2139",
     "description": "information source",
     "aliases": [
       "information_source"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⏪",
+    "emojiChar": "⏪",
+    "emoji": "\u23EA",
     "description": "black left-pointing double triangle",
     "aliases": [
       "rewind"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⏩",
+    "emojiChar": "⏩",
+    "emoji": "\u23E9",
     "description": "black right-pointing double triangle",
     "aliases": [
       "fast_forward"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⏫",
+    "emojiChar": "⏫",
+    "emoji": "\u23EB",
     "description": "black up-pointing double triangle",
     "aliases": [
       "arrow_double_up"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⏬",
+    "emojiChar": "⏬",
+    "emoji": "\u23EC",
     "description": "black down-pointing double triangle",
     "aliases": [
       "arrow_double_down"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⤵",
+    "emojiChar": "⤵",
+    "emoji": "\u2935",
     "description": "arrow pointing rightwards then curving downwards",
     "aliases": [
       "arrow_heading_down"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⤴",
+    "emojiChar": "⤴",
+    "emoji": "\u2934",
     "description": "arrow pointing rightwards then curving upwards",
     "aliases": [
       "arrow_heading_up"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆗",
+    "emojiChar": "🆗",
+    "emoji": "\uD83C\uDD97",
     "description": "squared ok",
     "aliases": [
       "ok"
@@ -6570,7 +6871,8 @@
     ]
   },
   {
-    "emoji": "🔀",
+    "emojiChar": "🔀",
+    "emoji": "\uD83D\uDD00",
     "description": "twisted rightwards arrows",
     "aliases": [
       "twisted_rightwards_arrows"
@@ -6580,7 +6882,8 @@
     ]
   },
   {
-    "emoji": "🔁",
+    "emojiChar": "🔁",
+    "emoji": "\uD83D\uDD01",
     "description": "clockwise rightwards and leftwards open circle arrows",
     "aliases": [
       "repeat"
@@ -6590,16 +6893,17 @@
     ]
   },
   {
-    "emoji": "🔂",
+    "emojiChar": "🔂",
+    "emoji": "\uD83D\uDD02",
     "description": "clockwise rightwards and leftwards open circle arrows with circled one overlay",
     "aliases": [
       "repeat_one"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆕",
+    "emojiChar": "🆕",
+    "emoji": "\uD83C\uDD95",
     "description": "squared new",
     "aliases": [
       "new"
@@ -6609,43 +6913,44 @@
     ]
   },
   {
-    "emoji": "🆙",
+    "emojiChar": "🆙",
+    "emoji": "\uD83C\uDD99",
     "description": "squared up with exclamation mark",
     "aliases": [
       "up"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆒",
+    "emojiChar": "🆒",
+    "emoji": "\uD83C\uDD92",
     "description": "squared cool",
     "aliases": [
       "cool"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆓",
+    "emojiChar": "🆓",
+    "emoji": "\uD83C\uDD93",
     "description": "squared free",
     "aliases": [
       "free"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆖",
+    "emojiChar": "🆖",
+    "emoji": "\uD83C\uDD96",
     "description": "squared ng",
     "aliases": [
       "squared_ng"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📶",
+    "emojiChar": "📶",
+    "emoji": "\uD83D\uDCF6",
     "description": "antenna with bars",
     "aliases": [
       "signal_strength"
@@ -6655,7 +6960,8 @@
     ]
   },
   {
-    "emoji": "🎦",
+    "emojiChar": "🎦",
+    "emoji": "\uD83C\uDFA6",
     "description": "cinema",
     "aliases": [
       "cinema"
@@ -6666,106 +6972,107 @@
     ]
   },
   {
-    "emoji": "🈁",
+    "emojiChar": "🈁",
+    "emoji": "\uD83C\uDE01",
     "description": "squared katakana koko",
     "aliases": [
       "koko"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈯",
+    "emojiChar": "🈯",
+    "emoji": "\uD83C\uDE2F",
     "description": "squared cjk unified ideograph-6307",
     "aliases": [
       "u6307"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈳",
+    "emojiChar": "🈳",
+    "emoji": "\uD83C\uDE33",
     "description": "squared cjk unified ideograph-7a7a",
     "aliases": [
       "u7a7a"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈵",
+    "emojiChar": "🈵",
+    "emoji": "\uD83C\uDE35",
     "description": "squared cjk unified ideograph-6e80",
     "aliases": [
       "u6e80"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈴",
+    "emojiChar": "🈴",
+    "emoji": "\uD83C\uDE34",
     "description": "squared cjk unified ideograph-5408",
     "aliases": [
       "u5408"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈲",
+    "emojiChar": "🈲",
+    "emoji": "\uD83C\uDE32",
     "description": "squared cjk unified ideograph-7981",
     "aliases": [
       "u7981"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🉐",
+    "emojiChar": "🉐",
+    "emoji": "\uD83C\uDE50",
     "description": "circled ideograph advantage",
     "aliases": [
       "ideograph_advantage"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈹",
+    "emojiChar": "🈹",
+    "emoji": "\uD83C\uDE39",
     "description": "squared cjk unified ideograph-5272",
     "aliases": [
       "u5272"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈺",
+    "emojiChar": "🈺",
+    "emoji": "\uD83C\uDE3A",
     "description": "squared cjk unified ideograph-55b6",
     "aliases": [
       "u55b6"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈶",
+    "emojiChar": "🈶",
+    "emoji": "\uD83C\uDE36",
     "description": "squared cjk unified ideograph-6709",
     "aliases": [
       "u6709"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈚",
+    "emojiChar": "🈚",
+    "emoji": "\uD83C\uDE1A",
     "description": "squared cjk unified ideograph-7121",
     "aliases": [
       "u7121"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚻",
+    "emojiChar": "🚻",
+    "emoji": "\uD83D\uDEBB",
     "description": "restroom",
     "aliases": [
       "restroom"
@@ -6775,34 +7082,35 @@
     ]
   },
   {
-    "emoji": "🚹",
+    "emojiChar": "🚹",
+    "emoji": "\uD83D\uDEB9",
     "description": "mens symbol",
     "aliases": [
       "mens"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚺",
+    "emojiChar": "🚺",
+    "emoji": "\uD83D\uDEBA",
     "description": "womens symbol",
     "aliases": [
       "womens"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚼",
+    "emojiChar": "🚼",
+    "emoji": "\uD83D\uDEBC",
     "description": "baby symbol",
     "aliases": [
       "baby_symbol"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚾",
+    "emojiChar": "🚾",
+    "emoji": "\uD83D\uDEBE",
     "description": "water closet",
     "aliases": [
       "wc"
@@ -6813,34 +7121,35 @@
     ]
   },
   {
-    "emoji": "🚰",
+    "emojiChar": "🚰",
+    "emoji": "\uD83D\uDEB0",
     "description": "potable water symbol",
     "aliases": [
       "potable_water"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚮",
+    "emojiChar": "🚮",
+    "emoji": "\uD83D\uDEAE",
     "description": "put litter in its place symbol",
     "aliases": [
       "put_litter_in_its_place"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🅿",
+    "emojiChar": "🅿",
+    "emoji": "\uD83C\uDD7F",
     "description": "negative squared latin capital letter p",
     "aliases": [
       "parking"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♿",
+    "emojiChar": "♿",
+    "emoji": "\u267F",
     "description": "wheelchair symbol",
     "aliases": [
       "wheelchair"
@@ -6850,61 +7159,62 @@
     ]
   },
   {
-    "emoji": "🚭",
+    "emojiChar": "🚭",
+    "emoji": "\uD83D\uDEAD",
     "description": "no smoking symbol",
     "aliases": [
       "no_smoking"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈷",
+    "emojiChar": "🈷",
+    "emoji": "\uD83C\uDE37",
     "description": "squared cjk unified ideograph-6708",
     "aliases": [
       "u6708"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈸",
+    "emojiChar": "🈸",
+    "emoji": "\uD83C\uDE38",
     "description": "squared cjk unified ideograph-7533",
     "aliases": [
       "u7533"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🈂",
+    "emojiChar": "🈂",
+    "emoji": "\uD83C\uDE02",
     "description": "squared katakana sa",
     "aliases": [
       "sa"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "Ⓜ",
+    "emojiChar": "Ⓜ",
+    "emoji": "\u24C2",
     "description": "circled latin capital letter m",
     "aliases": [
       "m"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🛂",
+    "emojiChar": "🛂",
+    "emoji": "\uD83D\uDEC2",
     "description": "passport control",
     "aliases": [
       "passport_control"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🛄",
+    "emojiChar": "🛄",
+    "emoji": "\uD83D\uDEC4",
     "description": "baggage claim",
     "aliases": [
       "baggage_claim"
@@ -6914,61 +7224,62 @@
     ]
   },
   {
-    "emoji": "🛅",
+    "emojiChar": "🛅",
+    "emoji": "\uD83D\uDEC5",
     "description": "left luggage",
     "aliases": [
       "left_luggage"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🛃",
+    "emojiChar": "🛃",
+    "emoji": "\uD83D\uDEC3",
     "description": "customs",
     "aliases": [
       "customs"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🉑",
+    "emojiChar": "🉑",
+    "emoji": "\uD83C\uDE51",
     "description": "circled ideograph accept",
     "aliases": [
       "accept"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "㊙",
+    "emojiChar": "㊙",
+    "emoji": "\u3299",
     "description": "circled ideograph secret",
     "aliases": [
       "secret"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "㊗",
+    "emojiChar": "㊗",
+    "emoji": "\u3297",
     "description": "circled ideograph congratulation",
     "aliases": [
       "congratulations"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆑",
+    "emojiChar": "🆑",
+    "emoji": "\uD83C\uDD91",
     "description": "squared cl",
     "aliases": [
       "cl"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆘",
+    "emojiChar": "🆘",
+    "emoji": "\uD83C\uDD98",
     "description": "squared sos",
     "aliases": [
       "sos"
@@ -6979,16 +7290,17 @@
     ]
   },
   {
-    "emoji": "🆔",
+    "emojiChar": "🆔",
+    "emoji": "\uD83C\uDD94",
     "description": "squared id",
     "aliases": [
       "id"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚫",
+    "emojiChar": "🚫",
+    "emoji": "\uD83D\uDEAB",
     "description": "no entry sign",
     "aliases": [
       "no_entry_sign"
@@ -6999,70 +7311,71 @@
     ]
   },
   {
-    "emoji": "🔞",
+    "emojiChar": "🔞",
+    "emoji": "\uD83D\uDD1E",
     "description": "no one under eighteen symbol",
     "aliases": [
       "underage"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📵",
+    "emojiChar": "📵",
+    "emoji": "\uD83D\uDCF5",
     "description": "no mobile phones",
     "aliases": [
       "no_mobile_phones"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚯",
+    "emojiChar": "🚯",
+    "emoji": "\uD83D\uDEAF",
     "description": "do not litter symbol",
     "aliases": [
       "do_not_litter"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚱",
+    "emojiChar": "🚱",
+    "emoji": "\uD83D\uDEB1",
     "description": "non-potable water symbol",
     "aliases": [
       "non-potable_water"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚳",
+    "emojiChar": "🚳",
+    "emoji": "\uD83D\uDEB3",
     "description": "no bicycles",
     "aliases": [
       "no_bicycles"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚷",
+    "emojiChar": "🚷",
+    "emoji": "\uD83D\uDEB7",
     "description": "no pedestrians",
     "aliases": [
       "no_pedestrians"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🚸",
+    "emojiChar": "🚸",
+    "emoji": "\uD83D\uDEB8",
     "description": "children crossing",
     "aliases": [
       "children_crossing"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛔",
+    "emojiChar": "⛔",
+    "emoji": "\u26D4",
     "description": "no entry",
     "aliases": [
       "no_entry"
@@ -7072,79 +7385,80 @@
     ]
   },
   {
-    "emoji": "✳",
+    "emojiChar": "✳",
+    "emoji": "\u2733",
     "description": "eight spoked asterisk",
     "aliases": [
       "eight_spoked_asterisk"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "❇",
+    "emojiChar": "❇",
+    "emoji": "\u2747",
     "description": "sparkle",
     "aliases": [
       "sparkle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "❎",
+    "emojiChar": "❎",
+    "emoji": "\u274E",
     "description": "negative squared cross mark",
     "aliases": [
       "negative_squared_cross_mark"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✅",
+    "emojiChar": "✅",
+    "emoji": "\u2705",
     "description": "white heavy check mark",
     "aliases": [
       "white_check_mark"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✴",
+    "emojiChar": "✴",
+    "emoji": "\u2734",
     "description": "eight pointed black star",
     "aliases": [
       "eight_pointed_black_star"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💟",
+    "emojiChar": "💟",
+    "emoji": "\uD83D\uDC9F",
     "description": "heart decoration",
     "aliases": [
       "heart_decoration"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆚",
+    "emojiChar": "🆚",
+    "emoji": "\uD83C\uDD9A",
     "description": "squared vs",
     "aliases": [
       "vs"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📳",
+    "emojiChar": "📳",
+    "emoji": "\uD83D\uDCF3",
     "description": "vibration mode",
     "aliases": [
       "vibration_mode"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "📴",
+    "emojiChar": "📴",
+    "emoji": "\uD83D\uDCF4",
     "description": "mobile phone off",
     "aliases": [
       "mobile_phone_off"
@@ -7155,61 +7469,62 @@
     ]
   },
   {
-    "emoji": "🅰",
+    "emojiChar": "🅰",
+    "emoji": "\uD83C\uDD70",
     "description": "negative squared latin capital letter a",
     "aliases": [
       "a"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🅱",
+    "emojiChar": "🅱",
+    "emoji": "\uD83C\uDD71",
     "description": "negative squared latin capital letter b",
     "aliases": [
       "b"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🆎",
+    "emojiChar": "🆎",
+    "emoji": "\uD83C\uDD8E",
     "description": "negative squared ab",
     "aliases": [
       "ab"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🅾",
+    "emojiChar": "🅾",
+    "emoji": "\uD83C\uDD7E",
     "description": "negative squared latin capital letter o",
     "aliases": [
       "o2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💠",
+    "emojiChar": "💠",
+    "emoji": "\uD83D\uDCA0",
     "description": "diamond shape with a dot inside",
     "aliases": [
       "diamond_shape_with_a_dot_inside"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "➿",
+    "emojiChar": "➿",
+    "emoji": "\u27BF",
     "description": "double curly loop",
     "aliases": [
       "loop"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♻",
+    "emojiChar": "♻",
+    "emoji": "\u267B",
     "description": "black universal recycling symbol",
     "aliases": [
       "recycle"
@@ -7220,187 +7535,188 @@
     ]
   },
   {
-    "emoji": "♈",
+    "emojiChar": "♈",
+    "emoji": "\u2648",
     "description": "aries",
     "aliases": [
       "aries"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♉",
+    "emojiChar": "♉",
+    "emoji": "\u2649",
     "description": "taurus",
     "aliases": [
       "taurus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♊",
+    "emojiChar": "♊",
+    "emoji": "\u264A",
     "description": "gemini",
     "aliases": [
       "gemini"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♋",
+    "emojiChar": "♋",
+    "emoji": "\u264B",
     "description": "cancer",
     "aliases": [
       "cancer"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♌",
+    "emojiChar": "♌",
+    "emoji": "\u264C",
     "description": "leo",
     "aliases": [
       "leo"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♍",
+    "emojiChar": "♍",
+    "emoji": "\u264D",
     "description": "virgo",
     "aliases": [
       "virgo"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♎",
+    "emojiChar": "♎",
+    "emoji": "\u264E",
     "description": "libra",
     "aliases": [
       "libra"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♏",
+    "emojiChar": "♏",
+    "emoji": "\u264F",
     "description": "scorpius",
     "aliases": [
       "scorpius"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♐",
+    "emojiChar": "♐",
+    "emoji": "\u2650",
     "description": "sagittarius",
     "aliases": [
       "sagittarius"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♑",
+    "emojiChar": "♑",
+    "emoji": "\u2651",
     "description": "capricorn",
     "aliases": [
       "capricorn"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♒",
+    "emojiChar": "♒",
+    "emoji": "\u2652",
     "description": "aquarius",
     "aliases": [
       "aquarius"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♓",
+    "emojiChar": "♓",
+    "emoji": "\u2653",
     "description": "pisces",
     "aliases": [
       "pisces"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⛎",
+    "emojiChar": "⛎",
+    "emoji": "\u26CE",
     "description": "ophiuchus",
     "aliases": [
       "ophiuchus"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔯",
+    "emojiChar": "🔯",
+    "emoji": "\uD83D\uDD2F",
     "description": "six pointed star with middle dot",
     "aliases": [
       "six_pointed_star"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🏧",
+    "emojiChar": "🏧",
+    "emoji": "\uD83C\uDFE7",
     "description": "automated teller machine",
     "aliases": [
       "atm"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💹",
+    "emojiChar": "💹",
+    "emoji": "\uD83D\uDCB9",
     "description": "chart with upwards trend and yen sign",
     "aliases": [
       "chart"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💲",
+    "emojiChar": "💲",
+    "emoji": "\uD83D\uDCB2",
     "description": "heavy dollar sign",
     "aliases": [
       "heavy_dollar_sign"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💱",
+    "emojiChar": "💱",
+    "emoji": "\uD83D\uDCB1",
     "description": "currency exchange",
     "aliases": [
       "currency_exchange"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "©",
+    "emojiChar": "©",
+    "emoji": "\u00A9",
     "description": "copyright sign",
     "aliases": [
       "copyright"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "®",
+    "emojiChar": "®",
+    "emoji": "\u00AE",
     "description": "registered sign",
     "aliases": [
       "registered"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "™",
+    "emojiChar": "™",
+    "emoji": "\u2122",
     "description": "trade mark sign",
     "aliases": [
       "tm"
@@ -7410,34 +7726,35 @@
     ]
   },
   {
-    "emoji": "❌",
+    "emojiChar": "❌",
+    "emoji": "\u274C",
     "description": "cross mark",
     "aliases": [
       "x"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "‼",
+    "emojiChar": "‼",
+    "emoji": "\u203C",
     "description": "double exclamation mark",
     "aliases": [
       "bangbang"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⁉",
+    "emojiChar": "⁉",
+    "emoji": "\u2049",
     "description": "exclamation question mark",
     "aliases": [
       "interrobang"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "❗",
+    "emojiChar": "❗",
+    "emoji": "\u2757",
     "description": "heavy exclamation mark symbol",
     "aliases": [
       "exclamation",
@@ -7448,7 +7765,8 @@
     ]
   },
   {
-    "emoji": "❓",
+    "emojiChar": "❓",
+    "emoji": "\u2753",
     "description": "black question mark ornament",
     "aliases": [
       "question"
@@ -7458,385 +7776,386 @@
     ]
   },
   {
-    "emoji": "❕",
+    "emojiChar": "❕",
+    "emoji": "\u2755",
     "description": "white exclamation mark ornament",
     "aliases": [
       "grey_exclamation"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "❔",
+    "emojiChar": "❔",
+    "emoji": "\u2754",
     "description": "white question mark ornament",
     "aliases": [
       "grey_question"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⭕",
+    "emojiChar": "⭕",
+    "emoji": "\u2B55",
     "description": "heavy large circle",
     "aliases": [
       "o"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔝",
+    "emojiChar": "🔝",
+    "emoji": "\uD83D\uDD1D",
     "description": "top with upwards arrow above",
     "aliases": [
       "top"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔚",
+    "emojiChar": "🔚",
+    "emoji": "\uD83D\uDD1A",
     "description": "end with leftwards arrow above",
     "aliases": [
       "end"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔙",
+    "emojiChar": "🔙",
+    "emoji": "\uD83D\uDD19",
     "description": "back with leftwards arrow above",
     "aliases": [
       "back"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔛",
+    "emojiChar": "🔛",
+    "emoji": "\uD83D\uDD1B",
     "description": "on with exclamation mark with left right arrow above",
     "aliases": [
       "on"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔜",
+    "emojiChar": "🔜",
+    "emoji": "\uD83D\uDD1C",
     "description": "soon with rightwards arrow above",
     "aliases": [
       "soon"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔃",
+    "emojiChar": "🔃",
+    "emoji": "\uD83D\uDD03",
     "description": "clockwise downwards and upwards open circle arrows",
     "aliases": [
       "arrows_clockwise"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕛",
+    "emojiChar": "🕛",
+    "emoji": "\uD83D\uDD5B",
     "description": "clock face twelve oclock",
     "aliases": [
       "clock12"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕧",
+    "emojiChar": "🕧",
+    "emoji": "\uD83D\uDD67",
     "description": "clock face twelve-thirty",
     "aliases": [
       "clock1230"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕐",
+    "emojiChar": "🕐",
+    "emoji": "\uD83D\uDD50",
     "description": "clock face one oclock",
     "aliases": [
       "clock1"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕜",
+    "emojiChar": "🕜",
+    "emoji": "\uD83D\uDD5C",
     "description": "clock face one-thirty",
     "aliases": [
       "clock130"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕑",
+    "emojiChar": "🕑",
+    "emoji": "\uD83D\uDD51",
     "description": "clock face two oclock",
     "aliases": [
       "clock2"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕝",
+    "emojiChar": "🕝",
+    "emoji": "\uD83D\uDD5D",
     "description": "clock face two-thirty",
     "aliases": [
       "clock230"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕒",
+    "emojiChar": "🕒",
+    "emoji": "\uD83D\uDD52",
     "description": "clock face three oclock",
     "aliases": [
       "clock3"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕞",
+    "emojiChar": "🕞",
+    "emoji": "\uD83D\uDD5E",
     "description": "clock face three-thirty",
     "aliases": [
       "clock330"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕓",
+    "emojiChar": "🕓",
+    "emoji": "\uD83D\uDD53",
     "description": "clock face four oclock",
     "aliases": [
       "clock4"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕟",
+    "emojiChar": "🕟",
+    "emoji": "\uD83D\uDD5F",
     "description": "clock face four-thirty",
     "aliases": [
       "clock430"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕔",
+    "emojiChar": "🕔",
+    "emoji": "\uD83D\uDD54",
     "description": "clock face five oclock",
     "aliases": [
       "clock5"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕠",
+    "emojiChar": "🕠",
+    "emoji": "\uD83D\uDD60",
     "description": "clock face five-thirty",
     "aliases": [
       "clock530"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕕",
+    "emojiChar": "🕕",
+    "emoji": "\uD83D\uDD55",
     "description": "clock face six oclock",
     "aliases": [
       "clock6"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕖",
+    "emojiChar": "🕖",
+    "emoji": "\uD83D\uDD56",
     "description": "clock face seven oclock",
     "aliases": [
       "clock7"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕗",
+    "emojiChar": "🕗",
+    "emoji": "\uD83D\uDD57",
     "description": "clock face eight oclock",
     "aliases": [
       "clock8"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕘",
+    "emojiChar": "🕘",
+    "emoji": "\uD83D\uDD58",
     "description": "clock face nine oclock",
     "aliases": [
       "clock9"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕙",
+    "emojiChar": "🕙",
+    "emoji": "\uD83D\uDD59",
     "description": "clock face ten oclock",
     "aliases": [
       "clock10"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕚",
+    "emojiChar": "🕚",
+    "emoji": "\uD83D\uDD5A",
     "description": "clock face eleven oclock",
     "aliases": [
       "clock11"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕡",
+    "emojiChar": "🕡",
+    "emoji": "\uD83D\uDD61",
     "description": "clock face six-thirty",
     "aliases": [
       "clock630"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕢",
+    "emojiChar": "🕢",
+    "emoji": "\uD83D\uDD62",
     "description": "clock face seven-thirty",
     "aliases": [
       "clock730"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕣",
+    "emojiChar": "🕣",
+    "emoji": "\uD83D\uDD63",
     "description": "clock face eight-thirty",
     "aliases": [
       "clock830"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕤",
+    "emojiChar": "🕤",
+    "emoji": "\uD83D\uDD64",
     "description": "clock face nine-thirty",
     "aliases": [
       "clock930"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕥",
+    "emojiChar": "🕥",
+    "emoji": "\uD83D\uDD65",
     "description": "clock face ten-thirty",
     "aliases": [
       "clock1030"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🕦",
+    "emojiChar": "🕦",
+    "emoji": "\uD83D\uDD66",
     "description": "clock face eleven-thirty",
     "aliases": [
       "clock1130"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "✖",
+    "emojiChar": "✖",
+    "emoji": "\u2716",
     "description": "heavy multiplication x",
     "aliases": [
       "heavy_multiplication_x"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "➕",
+    "emojiChar": "➕",
+    "emoji": "\u2795",
     "description": "heavy plus sign",
     "aliases": [
       "heavy_plus_sign"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "➖",
+    "emojiChar": "➖",
+    "emoji": "\u2796",
     "description": "heavy minus sign",
     "aliases": [
       "heavy_minus_sign"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "➗",
+    "emojiChar": "➗",
+    "emoji": "\u2797",
     "description": "heavy division sign",
     "aliases": [
       "heavy_division_sign"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♠",
+    "emojiChar": "♠",
+    "emoji": "\u2660",
     "description": "black spade suit",
     "aliases": [
       "spades"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♥",
+    "emojiChar": "♥",
+    "emoji": "\u2665",
     "description": "black heart suit",
     "aliases": [
       "hearts"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♣",
+    "emojiChar": "♣",
+    "emoji": "\u2663",
     "description": "black club suit",
     "aliases": [
       "clubs"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "♦",
+    "emojiChar": "♦",
+    "emoji": "\u2666",
     "description": "black diamond suit",
     "aliases": [
       "diamonds"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💮",
+    "emojiChar": "💮",
+    "emoji": "\uD83D\uDCAE",
     "description": "white flower",
     "aliases": [
       "white_flower"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "💯",
+    "emojiChar": "💯",
+    "emoji": "\uD83D\uDCAF",
     "description": "hundred points symbol",
     "aliases": [
       "100"
@@ -7847,2866 +8166,3104 @@
     ]
   },
   {
-    "emoji": "✔",
+    "emojiChar": "✔",
+    "emoji": "\u2714",
     "description": "heavy check mark",
     "aliases": [
       "heavy_check_mark"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "☑",
+    "emojiChar": "☑",
+    "emoji": "\u2611",
     "description": "ballot box with check",
     "aliases": [
       "ballot_box_with_check"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔘",
+    "emojiChar": "🔘",
+    "emoji": "\uD83D\uDD18",
     "description": "radio button",
     "aliases": [
       "radio_button"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔗",
+    "emojiChar": "🔗",
+    "emoji": "\uD83D\uDD17",
     "description": "link symbol",
     "aliases": [
       "link"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "➰",
+    "emojiChar": "➰",
+    "emoji": "\u27B0",
     "description": "curly loop",
     "aliases": [
       "curly_loop"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "〰",
+    "emojiChar": "〰",
+    "emoji": "\u3030",
     "description": "wavy dash",
     "aliases": [
       "wavy_dash"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "〽",
+    "emojiChar": "〽",
+    "emoji": "\u303D",
     "description": "part alternation mark",
     "aliases": [
       "part_alternation_mark"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔱",
+    "emojiChar": "🔱",
+    "emoji": "\uD83D\uDD31",
     "description": "trident emblem",
     "aliases": [
       "trident"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "◼",
+    "emojiChar": "◼",
+    "emoji": "\u25FC",
     "description": "black medium square",
     "aliases": [
       "black_medium_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "◻",
+    "emojiChar": "◻",
+    "emoji": "\u25FB",
     "description": "white medium square",
     "aliases": [
       "white_medium_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "◾",
+    "emojiChar": "◾",
+    "emoji": "\u25FE",
     "description": "black medium small square",
     "aliases": [
       "black_medium_small_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "◽",
+    "emojiChar": "◽",
+    "emoji": "\u25FD",
     "description": "white medium small square",
     "aliases": [
       "white_medium_small_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "▪",
+    "emojiChar": "▪",
+    "emoji": "\u25AA",
     "description": "black small square",
     "aliases": [
       "black_small_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "▫",
+    "emojiChar": "▫",
+    "emoji": "\u25AB",
     "description": "white small square",
     "aliases": [
       "white_small_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔺",
+    "emojiChar": "🔺",
+    "emoji": "\uD83D\uDD3A",
     "description": "up-pointing red triangle",
     "aliases": [
       "small_red_triangle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔲",
+    "emojiChar": "🔲",
+    "emoji": "\uD83D\uDD32",
     "description": "black square button",
     "aliases": [
       "black_square_button"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔳",
+    "emojiChar": "🔳",
+    "emoji": "\uD83D\uDD33",
     "description": "white square button",
     "aliases": [
       "white_square_button"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⚫",
+    "emojiChar": "⚫",
+    "emoji": "\u26AB",
     "description": "medium black circle",
     "aliases": [
       "black_circle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⚪",
+    "emojiChar": "⚪",
+    "emoji": "\u26AA",
     "description": "medium white circle",
     "aliases": [
       "white_circle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔴",
+    "emojiChar": "🔴",
+    "emoji": "\uD83D\uDD34",
     "description": "large red circle",
     "aliases": [
       "red_circle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔵",
+    "emojiChar": "🔵",
+    "emoji": "\uD83D\uDD35",
     "description": "large blue circle",
     "aliases": [
       "large_blue_circle"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔻",
+    "emojiChar": "🔻",
+    "emoji": "\uD83D\uDD3B",
     "description": "down-pointing red triangle",
     "aliases": [
       "small_red_triangle_down"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⬜",
+    "emojiChar": "⬜",
+    "emoji": "\u2B1C",
     "description": "white large square",
     "aliases": [
       "white_large_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "⬛",
+    "emojiChar": "⬛",
+    "emoji": "\u2B1B",
     "description": "black large square",
     "aliases": [
       "black_large_square"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔶",
+    "emojiChar": "🔶",
+    "emoji": "\uD83D\uDD36",
     "description": "large orange diamond",
     "aliases": [
       "large_orange_diamond"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔷",
+    "emojiChar": "🔷",
+    "emoji": "\uD83D\uDD37",
     "description": "large blue diamond",
     "aliases": [
       "large_blue_diamond"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔸",
+    "emojiChar": "🔸",
+    "emoji": "\uD83D\uDD38",
     "description": "small orange diamond",
     "aliases": [
       "small_orange_diamond"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
-    "emoji": "🔹",
+    "emojiChar": "🔹",
+    "emoji": "\uD83D\uDD39",
     "description": "small blue diamond",
     "aliases": [
       "small_blue_diamond"
     ],
-    "tags": [
-    ]
+    "tags": []
   },
   {
+    "emojiChar": "🇦🇫",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDEB",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter f",
+    "aliases": [
+      "af"
+    ],
     "tags": [
       "flag",
       "afghanistan"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter f",
-    "emoji": "🇦🇫",
-    "aliases": [
-      "af"
     ]
   },
   {
+    "emojiChar": "🇦🇱",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDF1",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter l",
+    "aliases": [
+      "al"
+    ],
     "tags": [
       "flag",
       "albania"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter l",
-    "emoji": "🇦🇱",
-    "aliases": [
-      "al"
     ]
   },
   {
+    "emojiChar": "🇩🇿",
+    "emoji": "\uD83C\uDDE9\uD83C\uDDFF",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter z",
+    "aliases": [
+      "dz"
+    ],
     "tags": [
       "flag",
       "algeria"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter z",
-    "emoji": "🇩🇿",
-    "aliases": [
-      "dz"
     ]
   },
   {
+    "emojiChar": "🇦🇸",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDF8",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter s",
+    "aliases": [
+      "as"
+    ],
     "tags": [
       "flag",
       "american samoa"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter s",
-    "emoji": "🇦🇸",
-    "aliases": [
-      "as"
     ]
   },
   {
+    "emojiChar": "🇦🇩",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDE9",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter d",
+    "aliases": [
+      "ad"
+    ],
     "tags": [
       "flag",
       "andorra"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter d",
-    "emoji": "🇦🇩",
-    "aliases": [
-      "ad"
     ]
   },
   {
+    "emojiChar": "🇦🇴",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDF4",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter o",
+    "aliases": [
+      "ao"
+    ],
     "tags": [
       "flag",
       "angola"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter o",
-    "emoji": "🇦🇴",
-    "aliases": [
-      "ao"
     ]
   },
   {
+    "emojiChar": "🇦🇮",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDEE",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter i",
+    "aliases": [
+      "ai"
+    ],
     "tags": [
       "flag",
       "anguilla"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter i",
-    "emoji": "🇦🇮",
-    "aliases": [
-      "ai"
     ]
   },
   {
+    "emojiChar": "🇦🇬",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDEC",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter g",
+    "aliases": [
+      "ag"
+    ],
     "tags": [
       "flag",
       "antigua and barbuda"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter g",
-    "emoji": "🇦🇬",
-    "aliases": [
-      "ag"
     ]
   },
   {
+    "emojiChar": "🇦🇷",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDF7",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter r",
+    "aliases": [
+      "ar"
+    ],
     "tags": [
       "flag",
       "argentina"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter r",
-    "emoji": "🇦🇷",
-    "aliases": [
-      "ar"
     ]
   },
   {
+    "emojiChar": "🇦🇲",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDF2",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter m",
+    "aliases": [
+      "am"
+    ],
     "tags": [
       "flag",
       "armenia"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter m",
-    "emoji": "🇦🇲",
-    "aliases": [
-      "am"
     ]
   },
   {
+    "emojiChar": "🇦🇼",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDFC",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter w",
+    "aliases": [
+      "aw"
+    ],
     "tags": [
       "flag",
       "aruba"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter w",
-    "emoji": "🇦🇼",
-    "aliases": [
-      "aw"
     ]
   },
   {
+    "emojiChar": "🇦🇺",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDFA",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter u",
+    "aliases": [
+      "au"
+    ],
     "tags": [
       "flag",
       "australia"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter u",
-    "emoji": "🇦🇺",
-    "aliases": [
-      "au"
     ]
   },
   {
+    "emojiChar": "🇦🇹",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDF9",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter t",
+    "aliases": [
+      "at"
+    ],
     "tags": [
       "flag",
       "austria"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter t",
-    "emoji": "🇦🇹",
-    "aliases": [
-      "at"
     ]
   },
   {
+    "emojiChar": "🇦🇿",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDFF",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter z",
+    "aliases": [
+      "az"
+    ],
     "tags": [
       "flag",
       "azerbaijan"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter z",
-    "emoji": "🇦🇿",
-    "aliases": [
-      "az"
     ]
   },
   {
+    "emojiChar": "🇧🇸",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDF8",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter s",
+    "aliases": [
+      "bs"
+    ],
     "tags": [
       "flag",
       "bahamas"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter s",
-    "emoji": "🇧🇸",
-    "aliases": [
-      "bs"
     ]
   },
   {
+    "emojiChar": "🇧🇭",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDED",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter h",
+    "aliases": [
+      "bh"
+    ],
     "tags": [
       "flag",
       "bahrain"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter h",
-    "emoji": "🇧🇭",
-    "aliases": [
-      "bh"
     ]
   },
   {
+    "emojiChar": "🇧🇩",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDE9",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter d",
+    "aliases": [
+      "bd"
+    ],
     "tags": [
       "flag",
       "bangladesh"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter d",
-    "emoji": "🇧🇩",
-    "aliases": [
-      "bd"
     ]
   },
   {
+    "emojiChar": "🇧🇧",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDE7",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter b",
+    "aliases": [
+      "bb"
+    ],
     "tags": [
       "flag",
       "barbados"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter b",
-    "emoji": "🇧🇧",
-    "aliases": [
-      "bb"
     ]
   },
   {
+    "emojiChar": "🇧🇾",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDFE",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter y",
+    "aliases": [
+      "by"
+    ],
     "tags": [
       "flag",
       "belarus"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter y",
-    "emoji": "🇧🇾",
-    "aliases": [
-      "by"
     ]
   },
   {
+    "emojiChar": "🇧🇪",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDEA",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter e",
+    "aliases": [
+      "be"
+    ],
     "tags": [
       "flag",
       "belgium"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter e",
-    "emoji": "🇧🇪",
-    "aliases": [
-      "be"
     ]
   },
   {
+    "emojiChar": "🇧🇿",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDFF",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter z",
+    "aliases": [
+      "bz"
+    ],
     "tags": [
       "flag",
       "belize"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter z",
-    "emoji": "🇧🇿",
-    "aliases": [
-      "bz"
     ]
   },
   {
+    "emojiChar": "🇧🇯",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDEF",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter j",
+    "aliases": [
+      "bj"
+    ],
     "tags": [
       "flag",
       "benin"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter j",
-    "emoji": "🇧🇯",
-    "aliases": [
-      "bj"
     ]
   },
   {
+    "emojiChar": "🇧🇲",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDF2",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter m",
+    "aliases": [
+      "bm"
+    ],
     "tags": [
       "flag",
       "bermuda"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter m",
-    "emoji": "🇧🇲",
-    "aliases": [
-      "bm"
     ]
   },
   {
+    "emojiChar": "🇧🇹",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDF9",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter t",
+    "aliases": [
+      "bt"
+    ],
     "tags": [
       "flag",
       "bhutan"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter t",
-    "emoji": "🇧🇹",
-    "aliases": [
-      "bt"
     ]
   },
   {
+    "emojiChar": "🇧🇴",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDF4",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter o",
+    "aliases": [
+      "bo"
+    ],
     "tags": [
       "flag",
       "bolivia"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter o",
-    "emoji": "🇧🇴",
-    "aliases": [
-      "bo"
     ]
   },
   {
+    "emojiChar": "🇧🇦",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDE6",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter a",
+    "aliases": [
+      "ba"
+    ],
     "tags": [
       "flag",
       "bosnia and herzegovina"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter a",
-    "emoji": "🇧🇦",
-    "aliases": [
-      "ba"
     ]
   },
   {
+    "emojiChar": "🇧🇼",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDFC",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter w",
+    "aliases": [
+      "bw"
+    ],
     "tags": [
       "flag",
       "botswana"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter w",
-    "emoji": "🇧🇼",
-    "aliases": [
-      "bw"
     ]
   },
   {
+    "emojiChar": "🇧🇷",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDF7",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter r",
+    "aliases": [
+      "br"
+    ],
     "tags": [
       "flag",
       "brazil"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter r",
-    "emoji": "🇧🇷",
-    "aliases": [
-      "br"
     ]
   },
   {
+    "emojiChar": "🇻🇬",
+    "emoji": "\uD83C\uDDFB\uD83C\uDDEC",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter g",
+    "aliases": [
+      "vg"
+    ],
     "tags": [
       "flag",
       "british virgin islands"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter g",
-    "emoji": "🇻🇬",
-    "aliases": [
-      "vg"
     ]
   },
   {
+    "emojiChar": "🇧🇳",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDF3",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter n",
+    "aliases": [
+      "bn"
+    ],
     "tags": [
       "flag",
       "brunei darussalam"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter n",
-    "emoji": "🇧🇳",
-    "aliases": [
-      "bn"
     ]
   },
   {
+    "emojiChar": "🇧🇬",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDEC",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter g",
+    "aliases": [
+      "bg"
+    ],
     "tags": [
       "flag",
       "bulgaria"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter g",
-    "emoji": "🇧🇬",
-    "aliases": [
-      "bg"
     ]
   },
   {
+    "emojiChar": "🇧🇫",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDEB",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter f",
+    "aliases": [
+      "bf"
+    ],
     "tags": [
       "flag",
       "burkina faso"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter f",
-    "emoji": "🇧🇫",
-    "aliases": [
-      "bf"
     ]
   },
   {
+    "emojiChar": "🇧🇮",
+    "emoji": "\uD83C\uDDE7\uD83C\uDDEE",
+    "description": "regional indicator symbol letter b + regional indicator symbol letter i",
+    "aliases": [
+      "bi"
+    ],
     "tags": [
       "flag",
       "burundi"
-    ],
-    "description": "regional indicator symbol letter b + regional indicator symbol letter i",
-    "emoji": "🇧🇮",
-    "aliases": [
-      "bi"
     ]
   },
   {
+    "emojiChar": "🇰🇭",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDED",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter h",
+    "aliases": [
+      "kh"
+    ],
     "tags": [
       "flag",
       "cambodia"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter h",
-    "emoji": "🇰🇭",
-    "aliases": [
-      "kh"
     ]
   },
   {
+    "emojiChar": "🇨🇲",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDF2",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter m",
+    "aliases": [
+      "cm"
+    ],
     "tags": [
       "flag",
       "cameroon"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter m",
-    "emoji": "🇨🇲",
-    "aliases": [
-      "cm"
     ]
   },
   {
+    "emojiChar": "🇨🇦",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDE6",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter a",
+    "aliases": [
+      "ca"
+    ],
     "tags": [
       "flag",
       "canada"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter a",
-    "emoji": "🇨🇦",
-    "aliases": [
-      "ca"
     ]
   },
   {
+    "emojiChar": "🇨🇻",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDFB",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter v",
+    "aliases": [
+      "cv"
+    ],
     "tags": [
       "flag",
       "cape verde"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter v",
-    "emoji": "🇨🇻",
-    "aliases": [
-      "cv"
     ]
   },
   {
+    "emojiChar": "🇰🇾",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDFE",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter y",
+    "aliases": [
+      "ky"
+    ],
     "tags": [
       "flag",
       "cayman islands"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter y",
-    "emoji": "🇰🇾",
-    "aliases": [
-      "ky"
     ]
   },
   {
+    "emojiChar": "🇨🇫",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDEB",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter f",
+    "aliases": [
+      "cf"
+    ],
     "tags": [
       "flag",
       "central african republic"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter f",
-    "emoji": "🇨🇫",
-    "aliases": [
-      "cf"
     ]
   },
   {
+    "emojiChar": "🇨🇱",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDF1",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter l",
+    "aliases": [
+      "cl_flag"
+    ],
     "tags": [
       "flag",
       "chile"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter l",
-    "emoji": "🇨🇱",
-    "aliases": [
-      "cl_flag"
     ]
   },
   {
+    "emojiChar": "🇨🇳",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDF3",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter n",
+    "aliases": [
+      "cn"
+    ],
     "tags": [
       "flag",
       "china"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter n",
-    "emoji": "🇨🇳",
-    "aliases": [
-      "cn"
     ]
   },
   {
+    "emojiChar": "🇨🇴",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDF4",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter o",
+    "aliases": [
+      "co"
+    ],
     "tags": [
       "flag",
       "colombia"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter o",
-    "emoji": "🇨🇴",
-    "aliases": [
-      "co"
     ]
   },
   {
+    "emojiChar": "🇰🇲",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDF2",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter m",
+    "aliases": [
+      "km"
+    ],
     "tags": [
       "flag",
       "comoros"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter m",
-    "emoji": "🇰🇲",
-    "aliases": [
-      "km"
     ]
   },
   {
+    "emojiChar": "🇨🇩",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDE9",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter d",
+    "aliases": [
+      "cd_flag"
+    ],
     "tags": [
       "flag",
       "democratic republic of the congo"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter d",
-    "emoji": "🇨🇩",
-    "aliases": [
-      "cd_flag"
     ]
   },
   {
+    "emojiChar": "🇨🇬",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDEC",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter g",
+    "aliases": [
+      "cg"
+    ],
     "tags": [
       "flag",
       "republic of the congo"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter g",
-    "emoji": "🇨🇬",
-    "aliases": [
-      "cg"
     ]
   },
   {
+    "emojiChar": "🇨🇰",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDF0",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter k",
+    "aliases": [
+      "ck"
+    ],
     "tags": [
       "flag",
       "cook islands"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter k",
-    "emoji": "🇨🇰",
-    "aliases": [
-      "ck"
     ]
   },
   {
+    "emojiChar": "🇨🇷",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDF7",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter r",
+    "aliases": [
+      "cr"
+    ],
     "tags": [
       "flag",
       "costa rica"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter r",
-    "emoji": "🇨🇷",
-    "aliases": [
-      "cr"
     ]
   },
   {
+    "emojiChar": "🇭🇷",
+    "emoji": "\uD83C\uDDED\uD83C\uDDF7",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter r",
+    "aliases": [
+      "hr"
+    ],
     "tags": [
       "flag",
       "croatia"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter r",
-    "emoji": "🇭🇷",
-    "aliases": [
-      "hr"
     ]
   },
   {
+    "emojiChar": "🇨🇺",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDFA",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter u",
+    "aliases": [
+      "cu"
+    ],
     "tags": [
       "flag",
       "cuba"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter u",
-    "emoji": "🇨🇺",
-    "aliases": [
-      "cu"
     ]
   },
   {
+    "emojiChar": "🇨🇼",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDFC",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter w",
+    "aliases": [
+      "cw"
+    ],
     "tags": [
       "flag",
       "curacao"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter w",
-    "emoji": "🇨🇼",
-    "aliases": [
-      "cw"
     ]
   },
   {
+    "emojiChar": "🇨🇾",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDFE",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter y",
+    "aliases": [
+      "cy"
+    ],
     "tags": [
       "flag",
       "cyprus"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter y",
-    "emoji": "🇨🇾",
-    "aliases": [
-      "cy"
     ]
   },
   {
+    "emojiChar": "🇨🇿",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDFF",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter z",
+    "aliases": [
+      "cz"
+    ],
     "tags": [
       "flag",
       "czech republic"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter z",
-    "emoji": "🇨🇿",
-    "aliases": [
-      "cz"
     ]
   },
   {
+    "emojiChar": "🇩🇰",
+    "emoji": "\uD83C\uDDE9\uD83C\uDDF0",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter k",
+    "aliases": [
+      "dk"
+    ],
     "tags": [
       "flag",
       "denmark"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter k",
-    "emoji": "🇩🇰",
-    "aliases": [
-      "dk"
     ]
   },
   {
+    "emojiChar": "🇩🇯",
+    "emoji": "\uD83C\uDDE9\uD83C\uDDEF",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter j",
+    "aliases": [
+      "dj"
+    ],
     "tags": [
       "flag",
       "djibouti"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter j",
-    "emoji": "🇩🇯",
-    "aliases": [
-      "dj"
     ]
   },
   {
+    "emojiChar": "🇩🇲",
+    "emoji": "\uD83C\uDDE9\uD83C\uDDF2",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter m",
+    "aliases": [
+      "dm"
+    ],
     "tags": [
       "flag",
       "dominica"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter m",
-    "emoji": "🇩🇲",
-    "aliases": [
-      "dm"
     ]
   },
   {
+    "emojiChar": "🇩🇴",
+    "emoji": "\uD83C\uDDE9\uD83C\uDDF4",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter o",
+    "aliases": [
+      "do"
+    ],
     "tags": [
       "flag",
       "dominican republic"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter o",
-    "emoji": "🇩🇴",
-    "aliases": [
-      "do"
     ]
   },
   {
+    "emojiChar": "🇪🇨",
+    "emoji": "\uD83C\uDDEA\uD83C\uDDE8",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter c",
+    "aliases": [
+      "ec"
+    ],
     "tags": [
       "flag",
       "ecuador"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter c",
-    "emoji": "🇪🇨",
-    "aliases": [
-      "ec"
     ]
   },
   {
+    "emojiChar": "🇪🇬",
+    "emoji": "\uD83C\uDDEA\uD83C\uDDEC",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter g",
+    "aliases": [
+      "eg"
+    ],
     "tags": [
       "flag",
       "egypt"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter g",
-    "emoji": "🇪🇬",
-    "aliases": [
-      "eg"
     ]
   },
   {
+    "emojiChar": "🇸🇻",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDFB",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter v",
+    "aliases": [
+      "sv"
+    ],
     "tags": [
       "flag",
       "el salvador"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter v",
-    "emoji": "🇸🇻",
-    "aliases": [
-      "sv"
     ]
   },
   {
+    "emojiChar": "🇬🇶",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDF6",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter q",
+    "aliases": [
+      "gq"
+    ],
     "tags": [
       "flag",
       "equatorial guinea"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter q",
-    "emoji": "🇬🇶",
-    "aliases": [
-      "gq"
     ]
   },
   {
+    "emojiChar": "🇪🇷",
+    "emoji": "\uD83C\uDDEA\uD83C\uDDF7",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter r",
+    "aliases": [
+      "er"
+    ],
     "tags": [
       "flag",
       "eritrea"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter r",
-    "emoji": "🇪🇷",
-    "aliases": [
-      "er"
     ]
   },
   {
+    "emojiChar": "🇪🇪",
+    "emoji": "\uD83C\uDDEA\uD83C\uDDEA",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter e",
+    "aliases": [
+      "ee"
+    ],
     "tags": [
       "flag",
       "estonia"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter e",
-    "emoji": "🇪🇪",
-    "aliases": [
-      "ee"
     ]
   },
   {
+    "emojiChar": "🇪🇹",
+    "emoji": "\uD83C\uDDEA\uD83C\uDDF9",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter t",
+    "aliases": [
+      "et"
+    ],
     "tags": [
       "flag",
       "ethiopia"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter t",
-    "emoji": "🇪🇹",
-    "aliases": [
-      "et"
     ]
   },
   {
+    "emojiChar": "🇫🇴",
+    "emoji": "\uD83C\uDDEB\uD83C\uDDF4",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter o",
+    "aliases": [
+      "fo"
+    ],
     "tags": [
       "flag",
       "faroe islands"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter o",
-    "emoji": "🇫🇴",
-    "aliases": [
-      "fo"
     ]
   },
   {
+    "emojiChar": "🇫🇯",
+    "emoji": "\uD83C\uDDEB\uD83C\uDDEF",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter j",
+    "aliases": [
+      "fj"
+    ],
     "tags": [
       "flag",
       "fiji"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter j",
-    "emoji": "🇫🇯",
-    "aliases": [
-      "fj"
     ]
   },
   {
+    "emojiChar": "🇫🇮",
+    "emoji": "\uD83C\uDDEB\uD83C\uDDEE",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter i",
+    "aliases": [
+      "fi"
+    ],
     "tags": [
       "flag",
       "finland"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter i",
-    "emoji": "🇫🇮",
-    "aliases": [
-      "fi"
     ]
   },
   {
+    "emojiChar": "🇫🇷",
+    "emoji": "\uD83C\uDDEB\uD83C\uDDF7",
+    "description": "regional indicator symbol letter f + regional indicator symbol letter r",
+    "aliases": [
+      "fr"
+    ],
     "tags": [
       "flag",
       "france"
-    ],
-    "description": "regional indicator symbol letter f + regional indicator symbol letter r",
-    "emoji": "🇫🇷",
-    "aliases": [
-      "fr"
     ]
   },
   {
+    "emojiChar": "🇬🇫",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDEB",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter f",
+    "aliases": [
+      "gf"
+    ],
     "tags": [
       "flag",
       "french guiana"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter f",
-    "emoji": "🇬🇫",
-    "aliases": [
-      "gf"
     ]
   },
   {
+    "emojiChar": "🇹🇫",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDEB",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter f",
+    "aliases": [
+      "tf"
+    ],
     "tags": [
       "flag",
       "french southern territories"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter f",
-    "emoji": "🇹🇫",
-    "aliases": [
-      "tf"
     ]
   },
   {
+    "emojiChar": "🇬🇦",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDE6",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter a",
+    "aliases": [
+      "ga"
+    ],
     "tags": [
       "flag",
       "gabon"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter a",
-    "emoji": "🇬🇦",
-    "aliases": [
-      "ga"
     ]
   },
   {
+    "emojiChar": "🇬🇲",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDF2",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter m",
+    "aliases": [
+      "gm"
+    ],
     "tags": [
       "flag",
       "gambia"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter m",
-    "emoji": "🇬🇲",
-    "aliases": [
-      "gm"
     ]
   },
   {
+    "emojiChar": "🇬🇪",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDEA",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter e",
+    "aliases": [
+      "ge"
+    ],
     "tags": [
       "flag",
       "georgia"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter e",
-    "emoji": "🇬🇪",
-    "aliases": [
-      "ge"
     ]
   },
   {
+    "emojiChar": "🇩🇪",
+    "emoji": "\uD83C\uDDE9\uD83C\uDDEA",
+    "description": "regional indicator symbol letter d + regional indicator symbol letter e",
+    "aliases": [
+      "de"
+    ],
     "tags": [
       "flag",
       "germany"
-    ],
-    "description": "regional indicator symbol letter d + regional indicator symbol letter e",
-    "emoji": "🇩🇪",
-    "aliases": [
-      "de"
     ]
   },
   {
+    "emojiChar": "🇬🇭",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDED",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter h",
+    "aliases": [
+      "gh"
+    ],
     "tags": [
       "flag",
       "ghana"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter h",
-    "emoji": "🇬🇭",
-    "aliases": [
-      "gh"
     ]
   },
   {
+    "emojiChar": "🇬🇮",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDEE",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter i",
+    "aliases": [
+      "gi"
+    ],
     "tags": [
       "flag",
       "gibraltar"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter i",
-    "emoji": "🇬🇮",
-    "aliases": [
-      "gi"
     ]
   },
   {
+    "emojiChar": "🇬🇷",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDF7",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter r",
+    "aliases": [
+      "gr"
+    ],
     "tags": [
       "flag",
       "greece"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter r",
-    "emoji": "🇬🇷",
-    "aliases": [
-      "gr"
     ]
   },
   {
+    "emojiChar": "🇬🇩",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDE9",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter d",
+    "aliases": [
+      "gd"
+    ],
     "tags": [
       "flag",
       "grenada"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter d",
-    "emoji": "🇬🇩",
-    "aliases": [
-      "gd"
     ]
   },
   {
+    "emojiChar": "🇬🇵",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDF5",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter p",
+    "aliases": [
+      "gp"
+    ],
     "tags": [
       "flag",
       "guadeloupe"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter p",
-    "emoji": "🇬🇵",
-    "aliases": [
-      "gp"
     ]
   },
   {
+    "emojiChar": "🇬🇺",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDFA",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter u",
+    "aliases": [
+      "gu"
+    ],
     "tags": [
       "flag",
       "guam"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter u",
-    "emoji": "🇬🇺",
-    "aliases": [
-      "gu"
     ]
   },
   {
+    "emojiChar": "🇬🇹",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDF9",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter t",
+    "aliases": [
+      "gt"
+    ],
     "tags": [
       "flag",
       "guatemala"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter t",
-    "emoji": "🇬🇹",
-    "aliases": [
-      "gt"
     ]
   },
   {
+    "emojiChar": "🇬🇳",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDF3",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter n",
+    "aliases": [
+      "gn"
+    ],
     "tags": [
       "flag",
       "guinea"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter n",
-    "emoji": "🇬🇳",
-    "aliases": [
-      "gn"
     ]
   },
   {
+    "emojiChar": "🇬🇼",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDFC",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter w",
+    "aliases": [
+      "gw"
+    ],
     "tags": [
       "flag",
       "guinea-bissau"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter w",
-    "emoji": "🇬🇼",
-    "aliases": [
-      "gw"
     ]
   },
   {
+    "emojiChar": "🇬🇾",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDFE",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter y",
+    "aliases": [
+      "gy"
+    ],
     "tags": [
       "flag",
       "guyana"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter y",
-    "emoji": "🇬🇾",
-    "aliases": [
-      "gy"
     ]
   },
   {
+    "emojiChar": "🇭🇹",
+    "emoji": "\uD83C\uDDED\uD83C\uDDF9",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter t",
+    "aliases": [
+      "ht"
+    ],
     "tags": [
       "flag",
       "haiti"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter t",
-    "emoji": "🇭🇹",
-    "aliases": [
-      "ht"
     ]
   },
   {
+    "emojiChar": "🇭🇳",
+    "emoji": "\uD83C\uDDED\uD83C\uDDF3",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter n",
+    "aliases": [
+      "hn"
+    ],
     "tags": [
       "flag",
       "honduras"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter n",
-    "emoji": "🇭🇳",
-    "aliases": [
-      "hn"
     ]
   },
   {
+    "emojiChar": "🇭🇰",
+    "emoji": "\uD83C\uDDED\uD83C\uDDF0",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter k",
+    "aliases": [
+      "hk"
+    ],
     "tags": [
       "flag",
       "hong kong"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter k",
-    "emoji": "🇭🇰",
-    "aliases": [
-      "hk"
     ]
   },
   {
+    "emojiChar": "🇭🇺",
+    "emoji": "\uD83C\uDDED\uD83C\uDDFA",
+    "description": "regional indicator symbol letter h + regional indicator symbol letter u",
+    "aliases": [
+      "hu"
+    ],
     "tags": [
       "flag",
       "hungary"
-    ],
-    "description": "regional indicator symbol letter h + regional indicator symbol letter u",
-    "emoji": "🇭🇺",
-    "aliases": [
-      "hu"
     ]
   },
   {
+    "emojiChar": "🇮🇸",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDF8",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter s",
+    "aliases": [
+      "is"
+    ],
     "tags": [
       "flag",
       "iceland"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter s",
-    "emoji": "🇮🇸",
-    "aliases": [
-      "is"
     ]
   },
   {
+    "emojiChar": "🇮🇳",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDF3",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter n",
+    "aliases": [
+      "in"
+    ],
     "tags": [
       "flag",
       "india"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter n",
-    "emoji": "🇮🇳",
-    "aliases": [
-      "in"
     ]
   },
   {
+    "emojiChar": "🇮🇩",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDE9",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter d",
+    "aliases": [
+      "id_flag"
+    ],
     "tags": [
       "flag",
       "indonesia"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter d",
-    "emoji": "🇮🇩",
-    "aliases": [
-      "id_flag"
     ]
   },
   {
+    "emojiChar": "🇮🇷",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDF7",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter r",
+    "aliases": [
+      "ir"
+    ],
     "tags": [
       "flag",
       "iran"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter r",
-    "emoji": "🇮🇷",
-    "aliases": [
-      "ir"
     ]
   },
   {
+    "emojiChar": "🇮🇶",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDF6",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter q",
+    "aliases": [
+      "iq"
+    ],
     "tags": [
       "flag",
       "iraq"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter q",
-    "emoji": "🇮🇶",
-    "aliases": [
-      "iq"
     ]
   },
   {
+    "emojiChar": "🇮🇪",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDEA",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter e",
+    "aliases": [
+      "ie"
+    ],
     "tags": [
       "flag",
       "ireland"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter e",
-    "emoji": "🇮🇪",
-    "aliases": [
-      "ie"
     ]
   },
   {
+    "emojiChar": "🇮🇱",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDF1",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter l",
+    "aliases": [
+      "il"
+    ],
     "tags": [
       "flag",
       "israel"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter l",
-    "emoji": "🇮🇱",
-    "aliases": [
-      "il"
     ]
   },
   {
+    "emojiChar": "🇮🇹",
+    "emoji": "\uD83C\uDDEE\uD83C\uDDF9",
+    "description": "regional indicator symbol letter i + regional indicator symbol letter t",
+    "aliases": [
+      "it"
+    ],
     "tags": [
       "flag",
       "italy"
-    ],
-    "description": "regional indicator symbol letter i + regional indicator symbol letter t",
-    "emoji": "🇮🇹",
-    "aliases": [
-      "it"
     ]
   },
   {
+    "emojiChar": "🇨🇮",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDEE",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter i",
+    "aliases": [
+      "ci"
+    ],
     "tags": [
       "flag",
       "ivory coast"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter i",
-    "emoji": "🇨🇮",
-    "aliases": [
-      "ci"
     ]
   },
   {
+    "emojiChar": "🇯🇲",
+    "emoji": "\uD83C\uDDEF\uD83C\uDDF2",
+    "description": "regional indicator symbol letter j + regional indicator symbol letter m",
+    "aliases": [
+      "jm"
+    ],
     "tags": [
       "flag",
       "jamaica"
-    ],
-    "description": "regional indicator symbol letter j + regional indicator symbol letter m",
-    "emoji": "🇯🇲",
-    "aliases": [
-      "jm"
     ]
   },
   {
+    "emojiChar": "🇯🇵",
+    "emoji": "\uD83C\uDDEF\uD83C\uDDF5",
+    "description": "regional indicator symbol letter j + regional indicator symbol letter p",
+    "aliases": [
+      "jp"
+    ],
     "tags": [
       "flag",
       "japan"
-    ],
-    "description": "regional indicator symbol letter j + regional indicator symbol letter p",
-    "emoji": "🇯🇵",
-    "aliases": [
-      "jp"
     ]
   },
   {
+    "emojiChar": "🇯🇴",
+    "emoji": "\uD83C\uDDEF\uD83C\uDDF4",
+    "description": "regional indicator symbol letter j + regional indicator symbol letter o",
+    "aliases": [
+      "jo"
+    ],
     "tags": [
       "flag",
       "jordan"
-    ],
-    "description": "regional indicator symbol letter j + regional indicator symbol letter o",
-    "emoji": "🇯🇴",
-    "aliases": [
-      "jo"
     ]
   },
   {
+    "emojiChar": "🇰🇿",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDFF",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter z",
+    "aliases": [
+      "kz"
+    ],
     "tags": [
       "flag",
       "kazakhstan"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter z",
-    "emoji": "🇰🇿",
-    "aliases": [
-      "kz"
     ]
   },
   {
+    "emojiChar": "🇰🇪",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDEA",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter e",
+    "aliases": [
+      "ke"
+    ],
     "tags": [
       "flag",
       "kenya"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter e",
-    "emoji": "🇰🇪",
-    "aliases": [
-      "ke"
     ]
   },
   {
+    "emojiChar": "🇰🇮",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDEE",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter i",
+    "aliases": [
+      "ki"
+    ],
     "tags": [
       "flag",
       "kiribati"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter i",
-    "emoji": "🇰🇮",
-    "aliases": [
-      "ki"
     ]
   },
   {
+    "emojiChar": "🇰🇼",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDFC",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter w",
+    "aliases": [
+      "kw"
+    ],
     "tags": [
       "flag",
       "kuwait"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter w",
-    "emoji": "🇰🇼",
-    "aliases": [
-      "kw"
     ]
   },
   {
+    "emojiChar": "🇰🇬",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDEC",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter g",
+    "aliases": [
+      "kg"
+    ],
     "tags": [
       "flag",
       "kyrgyzstan"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter g",
-    "emoji": "🇰🇬",
-    "aliases": [
-      "kg"
     ]
   },
   {
+    "emojiChar": "🇱🇦",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDE6",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter a",
+    "aliases": [
+      "la"
+    ],
     "tags": [
       "flag",
       "laos"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter a",
-    "emoji": "🇱🇦",
-    "aliases": [
-      "la"
     ]
   },
   {
+    "emojiChar": "🇱🇻",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDFB",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter v",
+    "aliases": [
+      "lv"
+    ],
     "tags": [
       "flag",
       "latvia"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter v",
-    "emoji": "🇱🇻",
-    "aliases": [
-      "lv"
     ]
   },
   {
+    "emojiChar": "🇱🇧",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDE7",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter b",
+    "aliases": [
+      "lb"
+    ],
     "tags": [
       "flag",
       "lebanon"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter b",
-    "emoji": "🇱🇧",
-    "aliases": [
-      "lb"
     ]
   },
   {
+    "emojiChar": "🇱🇸",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDF8",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter s",
+    "aliases": [
+      "ls"
+    ],
     "tags": [
       "flag",
       "lesotho"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter s",
-    "emoji": "🇱🇸",
-    "aliases": [
-      "ls"
     ]
   },
   {
+    "emojiChar": "🇱🇷",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDF7",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter r",
+    "aliases": [
+      "lr"
+    ],
     "tags": [
       "flag",
       "liberia"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter r",
-    "emoji": "🇱🇷",
-    "aliases": [
-      "lr"
     ]
   },
   {
+    "emojiChar": "🇱🇾",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDFE",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter y",
+    "aliases": [
+      "ly"
+    ],
     "tags": [
       "flag",
       "libya"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter y",
-    "emoji": "🇱🇾",
-    "aliases": [
-      "ly"
     ]
   },
   {
+    "emojiChar": "🇱🇮",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDEE",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter i",
+    "aliases": [
+      "li"
+    ],
     "tags": [
       "flag",
       "liechtenstein"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter i",
-    "emoji": "🇱🇮",
-    "aliases": [
-      "li"
     ]
   },
   {
+    "emojiChar": "🇱🇹",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDF9",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter t",
+    "aliases": [
+      "lt"
+    ],
     "tags": [
       "flag",
       "lithuania"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter t",
-    "emoji": "🇱🇹",
-    "aliases": [
-      "lt"
     ]
   },
   {
+    "emojiChar": "🇱🇺",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDFA",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter u",
+    "aliases": [
+      "lu"
+    ],
     "tags": [
       "flag",
       "luxembourg"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter u",
-    "emoji": "🇱🇺",
-    "aliases": [
-      "lu"
     ]
   },
   {
+    "emojiChar": "🇲🇴",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF4",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter o",
+    "aliases": [
+      "mo"
+    ],
     "tags": [
       "flag",
       "macau"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter o",
-    "emoji": "🇲🇴",
-    "aliases": [
-      "mo"
     ]
   },
   {
+    "emojiChar": "🇲🇰",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF0",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter k",
+    "aliases": [
+      "mk"
+    ],
     "tags": [
       "flag",
       "macedonia"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter k",
-    "emoji": "🇲🇰",
-    "aliases": [
-      "mk"
     ]
   },
   {
+    "emojiChar": "🇲🇬",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDEC",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter g",
+    "aliases": [
+      "mg"
+    ],
     "tags": [
       "flag",
       "madagascar"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter g",
-    "emoji": "🇲🇬",
-    "aliases": [
-      "mg"
     ]
   },
   {
+    "emojiChar": "🇲🇼",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDFC",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter w",
+    "aliases": [
+      "mw"
+    ],
     "tags": [
       "flag",
       "malawi"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter w",
-    "emoji": "🇲🇼",
-    "aliases": [
-      "mw"
     ]
   },
   {
+    "emojiChar": "🇲🇾",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDFE",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter y",
+    "aliases": [
+      "my"
+    ],
     "tags": [
       "flag",
       "malaysia"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter y",
-    "emoji": "🇲🇾",
-    "aliases": [
-      "my"
     ]
   },
   {
+    "emojiChar": "🇲🇻",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDFB",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter v",
+    "aliases": [
+      "mv"
+    ],
     "tags": [
       "flag",
       "maldives"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter v",
-    "emoji": "🇲🇻",
-    "aliases": [
-      "mv"
     ]
   },
   {
+    "emojiChar": "🇲🇱",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF1",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter l",
+    "aliases": [
+      "ml"
+    ],
     "tags": [
       "flag",
       "mali"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter l",
-    "emoji": "🇲🇱",
-    "aliases": [
-      "ml"
     ]
   },
   {
+    "emojiChar": "🇲🇹",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF9",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter t",
+    "aliases": [
+      "mt"
+    ],
     "tags": [
       "flag",
       "malta"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter t",
-    "emoji": "🇲🇹",
-    "aliases": [
-      "mt"
     ]
   },
   {
+    "emojiChar": "🇲🇶",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF6",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter q",
+    "aliases": [
+      "mq"
+    ],
     "tags": [
       "flag",
       "martinique"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter q",
-    "emoji": "🇲🇶",
-    "aliases": [
-      "mq"
     ]
   },
   {
+    "emojiChar": "🇲🇷",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF7",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter r",
+    "aliases": [
+      "mr"
+    ],
     "tags": [
       "flag",
       "mauritania"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter r",
-    "emoji": "🇲🇷",
-    "aliases": [
-      "mr"
     ]
   },
   {
+    "emojiChar": "🇲🇽",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDFD",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter x",
+    "aliases": [
+      "mx"
+    ],
     "tags": [
       "flag",
       "mexico"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter x",
-    "emoji": "🇲🇽",
-    "aliases": [
-      "mx"
     ]
   },
   {
+    "emojiChar": "🇲🇩",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDE9",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter d",
+    "aliases": [
+      "md"
+    ],
     "tags": [
       "flag",
       "moldova"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter d",
-    "emoji": "🇲🇩",
-    "aliases": [
-      "md"
     ]
   },
   {
+    "emojiChar": "🇲🇳",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF3",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter n",
+    "aliases": [
+      "mn"
+    ],
     "tags": [
       "flag",
       "mongolia"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter n",
-    "emoji": "🇲🇳",
-    "aliases": [
-      "mn"
     ]
   },
   {
+    "emojiChar": "🇲🇪",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDEA",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter e",
+    "aliases": [
+      "me"
+    ],
     "tags": [
       "flag",
       "montenegro"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter e",
-    "emoji": "🇲🇪",
-    "aliases": [
-      "me"
     ]
   },
   {
+    "emojiChar": "🇲🇸",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF8",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter s",
+    "aliases": [
+      "ms"
+    ],
     "tags": [
       "flag",
       "montserrat"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter s",
-    "emoji": "🇲🇸",
-    "aliases": [
-      "ms"
     ]
   },
   {
+    "emojiChar": "🇲🇦",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDE6",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter a",
+    "aliases": [
+      "ma"
+    ],
     "tags": [
       "flag",
       "morocco"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter a",
-    "emoji": "🇲🇦",
-    "aliases": [
-      "ma"
     ]
   },
   {
+    "emojiChar": "🇲🇿",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDFF",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter z",
+    "aliases": [
+      "mz"
+    ],
     "tags": [
       "flag",
       "mozambique"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter z",
-    "emoji": "🇲🇿",
-    "aliases": [
-      "mz"
     ]
   },
   {
+    "emojiChar": "🇲🇲",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF2",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter m",
+    "aliases": [
+      "mm"
+    ],
     "tags": [
       "flag",
       "myanmar"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter m",
-    "emoji": "🇲🇲",
-    "aliases": [
-      "mm"
     ]
   },
   {
+    "emojiChar": "🇳🇦",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDE6",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter a",
+    "aliases": [
+      "na"
+    ],
     "tags": [
       "flag",
       "namibia"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter a",
-    "emoji": "🇳🇦",
-    "aliases": [
-      "na"
     ]
   },
   {
+    "emojiChar": "🇳🇵",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDF5",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter p",
+    "aliases": [
+      "np"
+    ],
     "tags": [
       "flag",
       "nepal"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter p",
-    "emoji": "🇳🇵",
-    "aliases": [
-      "np"
     ]
   },
   {
+    "emojiChar": "🇳🇱",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDF1",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter l",
+    "aliases": [
+      "nl"
+    ],
     "tags": [
       "flag",
       "netherlands"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter l",
-    "emoji": "🇳🇱",
-    "aliases": [
-      "nl"
     ]
   },
   {
+    "emojiChar": "🇳🇨",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDE8",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter c",
+    "aliases": [
+      "nc"
+    ],
     "tags": [
       "flag",
       "new caledonia"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter c",
-    "emoji": "🇳🇨",
-    "aliases": [
-      "nc"
     ]
   },
   {
+    "emojiChar": "🇳🇿",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDFF",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter z",
+    "aliases": [
+      "nz"
+    ],
     "tags": [
       "flag",
       "new zealand"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter z",
-    "emoji": "🇳🇿",
-    "aliases": [
-      "nz"
     ]
   },
   {
+    "emojiChar": "🇳🇮",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDEE",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter i",
+    "aliases": [
+      "ni"
+    ],
     "tags": [
       "flag",
       "nicaragua"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter i",
-    "emoji": "🇳🇮",
-    "aliases": [
-      "ni"
     ]
   },
   {
+    "emojiChar": "🇳🇪",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDEA",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter e",
+    "aliases": [
+      "ne"
+    ],
     "tags": [
       "flag",
       "niger"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter e",
-    "emoji": "🇳🇪",
-    "aliases": [
-      "ne"
     ]
   },
   {
+    "emojiChar": "🇳🇬",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDEC",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter g",
+    "aliases": [
+      "ng"
+    ],
     "tags": [
       "flag",
       "nigeria"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter g",
-    "emoji": "🇳🇬",
-    "aliases": [
-      "ng"
     ]
   },
   {
+    "emojiChar": "🇳🇺",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDFA",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter u",
+    "aliases": [
+      "nu"
+    ],
     "tags": [
       "flag",
       "niue"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter u",
-    "emoji": "🇳🇺",
-    "aliases": [
-      "nu"
     ]
   },
   {
+    "emojiChar": "🇰🇵",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDF5",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter p",
+    "aliases": [
+      "kp"
+    ],
     "tags": [
       "flag",
       "north korea"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter p",
-    "emoji": "🇰🇵",
-    "aliases": [
-      "kp"
     ]
   },
   {
+    "emojiChar": "🇲🇵",
+    "emoji": "\uD83C\uDDF2\uD83C\uDDF5",
+    "description": "regional indicator symbol letter m + regional indicator symbol letter p",
+    "aliases": [
+      "mp"
+    ],
     "tags": [
       "flag",
       "northern mariana islands"
-    ],
-    "description": "regional indicator symbol letter m + regional indicator symbol letter p",
-    "emoji": "🇲🇵",
-    "aliases": [
-      "mp"
     ]
   },
   {
+    "emojiChar": "🇳🇴",
+    "emoji": "\uD83C\uDDF3\uD83C\uDDF4",
+    "description": "regional indicator symbol letter n + regional indicator symbol letter o",
+    "aliases": [
+      "no"
+    ],
     "tags": [
       "flag",
       "norway"
-    ],
-    "description": "regional indicator symbol letter n + regional indicator symbol letter o",
-    "emoji": "🇳🇴",
-    "aliases": [
-      "no"
     ]
   },
   {
+    "emojiChar": "🇴🇲",
+    "emoji": "\uD83C\uDDF4\uD83C\uDDF2",
+    "description": "regional indicator symbol letter o + regional indicator symbol letter m",
+    "aliases": [
+      "om"
+    ],
     "tags": [
       "flag",
       "oman"
-    ],
-    "description": "regional indicator symbol letter o + regional indicator symbol letter m",
-    "emoji": "🇴🇲",
-    "aliases": [
-      "om"
     ]
   },
   {
+    "emojiChar": "🇵🇰",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDF0",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter k",
+    "aliases": [
+      "pk"
+    ],
     "tags": [
       "flag",
       "pakistan"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter k",
-    "emoji": "🇵🇰",
-    "aliases": [
-      "pk"
     ]
   },
   {
+    "emojiChar": "🇵🇼",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDFC",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter w",
+    "aliases": [
+      "pw"
+    ],
     "tags": [
       "flag",
       "palau"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter w",
-    "emoji": "🇵🇼",
-    "aliases": [
-      "pw"
     ]
   },
   {
+    "emojiChar": "🇵🇸",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDF8",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter s",
+    "aliases": [
+      "ps"
+    ],
     "tags": [
       "flag",
       "palestine"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter s",
-    "emoji": "🇵🇸",
-    "aliases": [
-      "ps"
     ]
   },
   {
+    "emojiChar": "🇵🇦",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDE6",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter a",
+    "aliases": [
+      "pa"
+    ],
     "tags": [
       "flag",
       "panama"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter a",
-    "emoji": "🇵🇦",
-    "aliases": [
-      "pa"
     ]
   },
   {
+    "emojiChar": "🇵🇬",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDEC",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter g",
+    "aliases": [
+      "pg"
+    ],
     "tags": [
       "flag",
       "papua new guinea"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter g",
-    "emoji": "🇵🇬",
-    "aliases": [
-      "pg"
     ]
   },
   {
+    "emojiChar": "🇵🇾",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDFE",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter y",
+    "aliases": [
+      "py"
+    ],
     "tags": [
       "flag",
       "paraguay"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter y",
-    "emoji": "🇵🇾",
-    "aliases": [
-      "py"
     ]
   },
   {
+    "emojiChar": "🇵🇪",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDEA",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter e",
+    "aliases": [
+      "pe"
+    ],
     "tags": [
       "flag",
       "peru"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter e",
-    "emoji": "🇵🇪",
-    "aliases": [
-      "pe"
     ]
   },
   {
+    "emojiChar": "🇵🇭",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDED",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter h",
+    "aliases": [
+      "ph"
+    ],
     "tags": [
       "flag",
       "philippines"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter h",
-    "emoji": "🇵🇭",
-    "aliases": [
-      "ph"
     ]
   },
   {
+    "emojiChar": "🇵🇱",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDF1",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter l",
+    "aliases": [
+      "pl"
+    ],
     "tags": [
       "flag",
       "poland"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter l",
-    "emoji": "🇵🇱",
-    "aliases": [
-      "pl"
     ]
   },
   {
+    "emojiChar": "🇵🇹",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDF9",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter t",
+    "aliases": [
+      "pt"
+    ],
     "tags": [
       "flag",
       "portugal"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter t",
-    "emoji": "🇵🇹",
-    "aliases": [
-      "pt"
     ]
   },
   {
+    "emojiChar": "🇵🇷",
+    "emoji": "\uD83C\uDDF5\uD83C\uDDF7",
+    "description": "regional indicator symbol letter p + regional indicator symbol letter r",
+    "aliases": [
+      "pr"
+    ],
     "tags": [
       "flag",
       "puerto rico"
-    ],
-    "description": "regional indicator symbol letter p + regional indicator symbol letter r",
-    "emoji": "🇵🇷",
-    "aliases": [
-      "pr"
     ]
   },
   {
+    "emojiChar": "🇶🇦",
+    "emoji": "\uD83C\uDDF6\uD83C\uDDE6",
+    "description": "regional indicator symbol letter q + regional indicator symbol letter a",
+    "aliases": [
+      "qa"
+    ],
     "tags": [
       "flag",
       "qatar"
-    ],
-    "description": "regional indicator symbol letter q + regional indicator symbol letter a",
-    "emoji": "🇶🇦",
-    "aliases": [
-      "qa"
     ]
   },
   {
+    "emojiChar": "🇷🇪",
+    "emoji": "\uD83C\uDDF7\uD83C\uDDEA",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter e",
+    "aliases": [
+      "re"
+    ],
     "tags": [
       "flag",
       "reunion"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter e",
-    "emoji": "🇷🇪",
-    "aliases": [
-      "re"
     ]
   },
   {
+    "emojiChar": "🇷🇴",
+    "emoji": "\uD83C\uDDF7\uD83C\uDDF4",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter o",
+    "aliases": [
+      "ro"
+    ],
     "tags": [
       "flag",
       "romania"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter o",
-    "emoji": "🇷🇴",
-    "aliases": [
-      "ro"
     ]
   },
   {
+    "emojiChar": "🇷🇺",
+    "emoji": "\uD83C\uDDF7\uD83C\uDDFA",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter u",
+    "aliases": [
+      "ru"
+    ],
     "tags": [
       "flag",
       "russia"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter u",
-    "emoji": "🇷🇺",
-    "aliases": [
-      "ru"
     ]
   },
   {
+    "emojiChar": "🇷🇼",
+    "emoji": "\uD83C\uDDF7\uD83C\uDDFC",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter w",
+    "aliases": [
+      "rw"
+    ],
     "tags": [
       "flag",
       "rwanda"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter w",
-    "emoji": "🇷🇼",
-    "aliases": [
-      "rw"
     ]
   },
   {
+    "emojiChar": "🇼🇸",
+    "emoji": "\uD83C\uDDFC\uD83C\uDDF8",
+    "description": "regional indicator symbol letter w + regional indicator symbol letter s",
+    "aliases": [
+      "ws"
+    ],
     "tags": [
       "flag",
       "samoa"
-    ],
-    "description": "regional indicator symbol letter w + regional indicator symbol letter s",
-    "emoji": "🇼🇸",
-    "aliases": [
-      "ws"
     ]
   },
   {
+    "emojiChar": "🇸🇲",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF2",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter m",
+    "aliases": [
+      "sm"
+    ],
     "tags": [
       "flag",
       "san marino"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter m",
-    "emoji": "🇸🇲",
-    "aliases": [
-      "sm"
     ]
   },
   {
+    "emojiChar": "🇸🇹",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF9",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter t",
+    "aliases": [
+      "st"
+    ],
     "tags": [
       "flag",
       "sao tome and principe"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter t",
-    "emoji": "🇸🇹",
-    "aliases": [
-      "st"
     ]
   },
   {
+    "emojiChar": "🇸🇦",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDE6",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter a",
+    "aliases": [
+      "sa_flag"
+    ],
     "tags": [
       "flag",
       "saudi arabia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter a",
-    "emoji": "🇸🇦",
-    "aliases": [
-      "sa_flag"
     ]
   },
   {
+    "emojiChar": "🇸🇳",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF3",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter n",
+    "aliases": [
+      "sn"
+    ],
     "tags": [
       "flag",
       "senegal"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter n",
-    "emoji": "🇸🇳",
-    "aliases": [
-      "sn"
     ]
   },
   {
+    "emojiChar": "🇷🇸",
+    "emoji": "\uD83C\uDDF7\uD83C\uDDF8",
+    "description": "regional indicator symbol letter r + regional indicator symbol letter s",
+    "aliases": [
+      "rs"
+    ],
     "tags": [
       "flag",
       "serbia"
-    ],
-    "description": "regional indicator symbol letter r + regional indicator symbol letter s",
-    "emoji": "🇷🇸",
-    "aliases": [
-      "rs"
     ]
   },
   {
+    "emojiChar": "🇸🇨",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDE8",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter c",
+    "aliases": [
+      "sc"
+    ],
     "tags": [
       "flag",
       "seychelles"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter c",
-    "emoji": "🇸🇨",
-    "aliases": [
-      "sc"
     ]
   },
   {
+    "emojiChar": "🇸🇱",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF1",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter l",
+    "aliases": [
+      "sl"
+    ],
     "tags": [
       "flag",
       "sierra leone"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter l",
-    "emoji": "🇸🇱",
-    "aliases": [
-      "sl"
     ]
   },
   {
+    "emojiChar": "🇸🇬",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDEC",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter g",
+    "aliases": [
+      "sg"
+    ],
     "tags": [
       "flag",
       "singapore"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter g",
-    "emoji": "🇸🇬",
-    "aliases": [
-      "sg"
     ]
   },
   {
+    "emojiChar": "🇸🇰",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF0",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter k",
+    "aliases": [
+      "sk"
+    ],
     "tags": [
       "flag",
       "slovakia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter k",
-    "emoji": "🇸🇰",
-    "aliases": [
-      "sk"
     ]
   },
   {
+    "emojiChar": "🇸🇮",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDEE",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter i",
+    "aliases": [
+      "si"
+    ],
     "tags": [
       "flag",
       "slovenia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter i",
-    "emoji": "🇸🇮",
-    "aliases": [
-      "si"
     ]
   },
   {
+    "emojiChar": "🇸🇧",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDE7",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter b",
+    "aliases": [
+      "sb"
+    ],
     "tags": [
       "flag",
       "solomon islands"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter b",
-    "emoji": "🇸🇧",
-    "aliases": [
-      "sb"
     ]
   },
   {
+    "emojiChar": "🇸🇴",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF4",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter o",
+    "aliases": [
+      "so"
+    ],
     "tags": [
       "flag",
       "somalia"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter o",
-    "emoji": "🇸🇴",
-    "aliases": [
-      "so"
     ]
   },
   {
+    "emojiChar": "🇿🇦",
+    "emoji": "\uD83C\uDDFF\uD83C\uDDE6",
+    "description": "regional indicator symbol letter z + regional indicator symbol letter a",
+    "aliases": [
+      "za"
+    ],
     "tags": [
       "flag",
       "south africa"
-    ],
-    "description": "regional indicator symbol letter z + regional indicator symbol letter a",
-    "emoji": "🇿🇦",
-    "aliases": [
-      "za"
     ]
   },
   {
+    "emojiChar": "🇰🇷",
+    "emoji": "\uD83C\uDDF0\uD83C\uDDF7",
+    "description": "regional indicator symbol letter k + regional indicator symbol letter r",
+    "aliases": [
+      "kr"
+    ],
     "tags": [
       "flag",
       "south korea"
-    ],
-    "description": "regional indicator symbol letter k + regional indicator symbol letter r",
-    "emoji": "🇰🇷",
-    "aliases": [
-      "kr"
     ]
   },
   {
+    "emojiChar": "🇸🇸",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF8",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter s",
+    "aliases": [
+      "ss"
+    ],
     "tags": [
       "flag",
       "south sudan"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter s",
-    "emoji": "🇸🇸",
-    "aliases": [
-      "ss"
     ]
   },
   {
+    "emojiChar": "🇪🇸",
+    "emoji": "\uD83C\uDDEA\uD83C\uDDF8",
+    "description": "regional indicator symbol letter e + regional indicator symbol letter s",
+    "aliases": [
+      "es"
+    ],
     "tags": [
       "flag",
       "spain"
-    ],
-    "description": "regional indicator symbol letter e + regional indicator symbol letter s",
-    "emoji": "🇪🇸",
-    "aliases": [
-      "es"
     ]
   },
   {
+    "emojiChar": "🇱🇰",
+    "emoji": "\uD83C\uDDF1\uD83C\uDDF0",
+    "description": "regional indicator symbol letter l + regional indicator symbol letter k",
+    "aliases": [
+      "lk"
+    ],
     "tags": [
       "flag",
       "sri lanka"
-    ],
-    "description": "regional indicator symbol letter l + regional indicator symbol letter k",
-    "emoji": "🇱🇰",
-    "aliases": [
-      "lk"
     ]
   },
   {
+    "emojiChar": "🇸🇩",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDE9",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter d",
+    "aliases": [
+      "sd"
+    ],
     "tags": [
       "flag",
       "sudan"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter d",
-    "emoji": "🇸🇩",
-    "aliases": [
-      "sd"
     ]
   },
   {
+    "emojiChar": "🇸🇷",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDF7",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter r",
+    "aliases": [
+      "sr"
+    ],
     "tags": [
       "flag",
       "suriname"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter r",
-    "emoji": "🇸🇷",
-    "aliases": [
-      "sr"
     ]
   },
   {
+    "emojiChar": "🇸🇿",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDFF",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter z",
+    "aliases": [
+      "sz"
+    ],
     "tags": [
       "flag",
       "swaziland"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter z",
-    "emoji": "🇸🇿",
-    "aliases": [
-      "sz"
     ]
   },
   {
+    "emojiChar": "🇸🇪",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDEA",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter e",
+    "aliases": [
+      "se"
+    ],
     "tags": [
       "flag",
       "sweden"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter e",
-    "emoji": "🇸🇪",
-    "aliases": [
-      "se"
     ]
   },
   {
+    "emojiChar": "🇨🇭",
+    "emoji": "\uD83C\uDDE8\uD83C\uDDED",
+    "description": "regional indicator symbol letter c + regional indicator symbol letter h",
+    "aliases": [
+      "ch"
+    ],
     "tags": [
       "flag",
       "switzerland"
-    ],
-    "description": "regional indicator symbol letter c + regional indicator symbol letter h",
-    "emoji": "🇨🇭",
-    "aliases": [
-      "ch"
     ]
   },
   {
+    "emojiChar": "🇸🇾",
+    "emoji": "\uD83C\uDDF8\uD83C\uDDFE",
+    "description": "regional indicator symbol letter s + regional indicator symbol letter y",
+    "aliases": [
+      "sy"
+    ],
     "tags": [
       "flag",
       "syria"
-    ],
-    "description": "regional indicator symbol letter s + regional indicator symbol letter y",
-    "emoji": "🇸🇾",
-    "aliases": [
-      "sy"
     ]
   },
   {
+    "emojiChar": "🇹🇯",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDEF",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter j",
+    "aliases": [
+      "tj"
+    ],
     "tags": [
       "flag",
       "tajikistan"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter j",
-    "emoji": "🇹🇯",
-    "aliases": [
-      "tj"
     ]
   },
   {
+    "emojiChar": "🇹🇿",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDFF",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter z",
+    "aliases": [
+      "tz"
+    ],
     "tags": [
       "flag",
       "tanzania"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter z",
-    "emoji": "🇹🇿",
-    "aliases": [
-      "tz"
     ]
   },
   {
+    "emojiChar": "🇹🇭",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDED",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter h",
+    "aliases": [
+      "th"
+    ],
     "tags": [
       "flag",
       "thailand"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter h",
-    "emoji": "🇹🇭",
-    "aliases": [
-      "th"
     ]
   },
   {
+    "emojiChar": "🇹🇱",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDF1",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter l",
+    "aliases": [
+      "tl"
+    ],
     "tags": [
       "flag",
       "east timor"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter l",
-    "emoji": "🇹🇱",
-    "aliases": [
-      "tl"
     ]
   },
   {
+    "emojiChar": "🇹🇬",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDEC",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter g",
+    "aliases": [
+      "tg"
+    ],
     "tags": [
       "flag",
       "togo"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter g",
-    "emoji": "🇹🇬",
-    "aliases": [
-      "tg"
     ]
   },
   {
+    "emojiChar": "🇹🇴",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDF4",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter o",
+    "aliases": [
+      "to"
+    ],
     "tags": [
       "flag",
       "tonga"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter o",
-    "emoji": "🇹🇴",
-    "aliases": [
-      "to"
     ]
   },
   {
+    "emojiChar": "🇹🇹",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDF9",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter t",
+    "aliases": [
+      "tt"
+    ],
     "tags": [
       "flag",
       "trinidad and tobago"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter t",
-    "emoji": "🇹🇹",
-    "aliases": [
-      "tt"
     ]
   },
   {
+    "emojiChar": "🇹🇳",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDF3",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter n",
+    "aliases": [
+      "tn"
+    ],
     "tags": [
       "flag",
       "tunisia"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter n",
-    "emoji": "🇹🇳",
-    "aliases": [
-      "tn"
     ]
   },
   {
+    "emojiChar": "🇹🇷",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDF7",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter r",
+    "aliases": [
+      "tr"
+    ],
     "tags": [
       "flag",
       "turkey"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter r",
-    "emoji": "🇹🇷",
-    "aliases": [
-      "tr"
     ]
   },
   {
+    "emojiChar": "🇹🇲",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDF2",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter m",
+    "aliases": [
+      "tm_flag"
+    ],
     "tags": [
       "flag",
       "turkmenistan"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter m",
-    "emoji": "🇹🇲",
-    "aliases": [
-      "tm_flag"
     ]
   },
   {
+    "emojiChar": "🇹🇨",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDE8",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter c",
+    "aliases": [
+      "tc"
+    ],
     "tags": [
       "flag",
       "turks and caicos islands"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter c",
-    "emoji": "🇹🇨",
-    "aliases": [
-      "tc"
     ]
   },
   {
+    "emojiChar": "🇹🇻",
+    "emoji": "\uD83C\uDDF9\uD83C\uDDFB",
+    "description": "regional indicator symbol letter t + regional indicator symbol letter v",
+    "aliases": [
+      "tv_flag"
+    ],
     "tags": [
       "flag",
       "tuvalu"
-    ],
-    "description": "regional indicator symbol letter t + regional indicator symbol letter v",
-    "emoji": "🇹🇻",
-    "aliases": [
-      "tv_flag"
     ]
   },
   {
+    "emojiChar": "🇺🇬",
+    "emoji": "\uD83C\uDDFA\uD83C\uDDEC",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter g",
+    "aliases": [
+      "ug"
+    ],
     "tags": [
       "flag",
       "uganda"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter g",
-    "emoji": "🇺🇬",
-    "aliases": [
-      "ug"
     ]
   },
   {
+    "emojiChar": "🇺🇦",
+    "emoji": "\uD83C\uDDFA\uD83C\uDDE6",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter a",
+    "aliases": [
+      "ua"
+    ],
     "tags": [
       "flag",
       "ukraine"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter a",
-    "emoji": "🇺🇦",
-    "aliases": [
-      "ua"
     ]
   },
   {
+    "emojiChar": "🇦🇪",
+    "emoji": "\uD83C\uDDE6\uD83C\uDDEA",
+    "description": "regional indicator symbol letter a + regional indicator symbol letter e",
+    "aliases": [
+      "ae"
+    ],
     "tags": [
       "flag",
       "united arab emirates"
-    ],
-    "description": "regional indicator symbol letter a + regional indicator symbol letter e",
-    "emoji": "🇦🇪",
-    "aliases": [
-      "ae"
     ]
   },
   {
+    "emojiChar": "🇬🇧",
+    "emoji": "\uD83C\uDDEC\uD83C\uDDE7",
+    "description": "regional indicator symbol letter g + regional indicator symbol letter b",
+    "aliases": [
+      "gb"
+    ],
     "tags": [
       "flag",
       "united kingdom"
-    ],
-    "description": "regional indicator symbol letter g + regional indicator symbol letter b",
-    "emoji": "🇬🇧",
-    "aliases": [
-      "gb"
     ]
   },
   {
+    "emojiChar": "🇺🇾",
+    "emoji": "\uD83C\uDDFA\uD83C\uDDFE",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter y",
+    "aliases": [
+      "uy"
+    ],
     "tags": [
       "flag",
       "uruguay"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter y",
-    "emoji": "🇺🇾",
-    "aliases": [
-      "uy"
     ]
   },
   {
+    "emojiChar": "🇺🇸",
+    "emoji": "\uD83C\uDDFA\uD83C\uDDF8",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter s",
+    "aliases": [
+      "us"
+    ],
     "tags": [
       "flag",
       "united states of america"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter s",
-    "emoji": "🇺🇸",
-    "aliases": [
-      "us"
     ]
   },
   {
+    "emojiChar": "🇻🇮",
+    "emoji": "\uD83C\uDDFB\uD83C\uDDEE",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter i",
+    "aliases": [
+      "vi"
+    ],
     "tags": [
       "flag",
       "us virgin islands"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter i",
-    "emoji": "🇻🇮",
-    "aliases": [
-      "vi"
     ]
   },
   {
+    "emojiChar": "🇺🇿",
+    "emoji": "\uD83C\uDDFA\uD83C\uDDFF",
+    "description": "regional indicator symbol letter u + regional indicator symbol letter z",
+    "aliases": [
+      "uz"
+    ],
     "tags": [
       "flag",
       "uzbekistan"
-    ],
-    "description": "regional indicator symbol letter u + regional indicator symbol letter z",
-    "emoji": "🇺🇿",
-    "aliases": [
-      "uz"
     ]
   },
   {
+    "emojiChar": "🇻🇨",
+    "emoji": "\uD83C\uDDFB\uD83C\uDDE8",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter c",
+    "aliases": [
+      "vc"
+    ],
     "tags": [
       "flag",
       "st vincent grenadines"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter c",
-    "emoji": "🇻🇨",
-    "aliases": [
-      "vc"
     ]
   },
   {
+    "emojiChar": "🇻🇺",
+    "emoji": "\uD83C\uDDFB\uD83C\uDDFA",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter u",
+    "aliases": [
+      "vu"
+    ],
     "tags": [
       "flag",
       "vanuatu"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter u",
-    "emoji": "🇻🇺",
-    "aliases": [
-      "vu"
     ]
   },
   {
+    "emojiChar": "🇻🇪",
+    "emoji": "\uD83C\uDDFB\uD83C\uDDEA",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter e",
+    "aliases": [
+      "ve"
+    ],
     "tags": [
       "flag",
       "venezuela"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter e",
-    "emoji": "🇻🇪",
-    "aliases": [
-      "ve"
     ]
   },
   {
+    "emojiChar": "🇻🇳",
+    "emoji": "\uD83C\uDDFB\uD83C\uDDF3",
+    "description": "regional indicator symbol letter v + regional indicator symbol letter n",
+    "aliases": [
+      "vn"
+    ],
     "tags": [
       "flag",
       "vietnam"
-    ],
-    "description": "regional indicator symbol letter v + regional indicator symbol letter n",
-    "emoji": "🇻🇳",
-    "aliases": [
-      "vn"
     ]
   },
   {
+    "emojiChar": "🇾🇪",
+    "emoji": "\uD83C\uDDFE\uD83C\uDDEA",
+    "description": "regional indicator symbol letter y + regional indicator symbol letter e",
+    "aliases": [
+      "ye"
+    ],
     "tags": [
       "flag",
       "yemen"
-    ],
-    "description": "regional indicator symbol letter y + regional indicator symbol letter e",
-    "emoji": "🇾🇪",
-    "aliases": [
-      "ye"
     ]
   },
   {
+    "emojiChar": "🇿🇲",
+    "emoji": "\uD83C\uDDFF\uD83C\uDDF2",
+    "description": "regional indicator symbol letter z + regional indicator symbol letter m",
+    "aliases": [
+      "zm"
+    ],
     "tags": [
       "flag",
       "zambia"
-    ],
-    "description": "regional indicator symbol letter z + regional indicator symbol letter m",
-    "emoji": "🇿🇲",
-    "aliases": [
-      "zm"
     ]
   },
   {
+    "emojiChar": "🇿🇼",
+    "emoji": "\uD83C\uDDFF\uD83C\uDDFC",
+    "description": "regional indicator symbol letter z + regional indicator symbol letter w",
+    "aliases": [
+      "zw"
+    ],
     "tags": [
       "flag",
       "zimbabwe"
-    ],
-    "description": "regional indicator symbol letter z + regional indicator symbol letter w",
-    "emoji": "🇿🇼",
-    "aliases": [
-      "zw"
     ]
   },
   {
+    "emojiChar": "🇦",
+    "emoji": "\uD83C\uDDE6",
+    "description": "regional indicator symbol letter a",
+    "aliases": [
+      "regional_indicator_symbol_a"
+    ],
     "tags": [
       "letter",
       "a"
-    ],
-    "description": "regional indicator symbol letter a",
-    "emoji": "🇦",
-    "aliases": [
-      "regional_indicator_symbol_a"
     ]
   },
   {
+    "emojiChar": "🇧",
+    "emoji": "\uD83C\uDDE7",
+    "description": "regional indicator symbol letter b",
+    "aliases": [
+      "regional_indicator_symbol_b"
+    ],
     "tags": [
       "letter",
       "b"
-    ],
-    "description": "regional indicator symbol letter b",
-    "emoji": "🇧",
-    "aliases": [
-      "regional_indicator_symbol_b"
     ]
   },
   {
+    "emojiChar": "🇨",
+    "emoji": "\uD83C\uDDE8",
+    "description": "regional indicator symbol letter c",
+    "aliases": [
+      "regional_indicator_symbol_c"
+    ],
     "tags": [
       "letter",
       "c"
-    ],
-    "description": "regional indicator symbol letter c",
-    "emoji": "🇨",
-    "aliases": [
-      "regional_indicator_symbol_c"
     ]
   },
   {
+    "emojiChar": "🇩",
+    "emoji": "\uD83C\uDDE9",
+    "description": "regional indicator symbol letter d",
+    "aliases": [
+      "regional_indicator_symbol_d"
+    ],
     "tags": [
       "letter",
       "d"
-    ],
-    "description": "regional indicator symbol letter d",
-    "emoji": "🇩",
-    "aliases": [
-      "regional_indicator_symbol_d"
     ]
   },
   {
+    "emojiChar": "🇪",
+    "emoji": "\uD83C\uDDEA",
+    "description": "regional indicator symbol letter e",
+    "aliases": [
+      "regional_indicator_symbol_e"
+    ],
     "tags": [
       "letter",
       "e"
-    ],
-    "description": "regional indicator symbol letter e",
-    "emoji": "🇪",
-    "aliases": [
-      "regional_indicator_symbol_e"
     ]
   },
   {
+    "emojiChar": "🇫",
+    "emoji": "\uD83C\uDDEB",
+    "description": "regional indicator symbol letter f",
+    "aliases": [
+      "regional_indicator_symbol_f"
+    ],
     "tags": [
       "letter",
       "f"
-    ],
-    "description": "regional indicator symbol letter f",
-    "emoji": "🇫",
-    "aliases": [
-      "regional_indicator_symbol_f"
     ]
   },
   {
+    "emojiChar": "🇬",
+    "emoji": "\uD83C\uDDEC",
+    "description": "regional indicator symbol letter g",
+    "aliases": [
+      "regional_indicator_symbol_g"
+    ],
     "tags": [
       "letter",
       "g"
-    ],
-    "description": "regional indicator symbol letter g",
-    "emoji": "🇬",
-    "aliases": [
-      "regional_indicator_symbol_g"
     ]
   },
   {
+    "emojiChar": "🇭",
+    "emoji": "\uD83C\uDDED",
+    "description": "regional indicator symbol letter h",
+    "aliases": [
+      "regional_indicator_symbol_h"
+    ],
     "tags": [
       "letter",
       "h"
-    ],
-    "description": "regional indicator symbol letter h",
-    "emoji": "🇭",
-    "aliases": [
-      "regional_indicator_symbol_h"
     ]
   },
   {
+    "emojiChar": "🇮",
+    "emoji": "\uD83C\uDDEE",
+    "description": "regional indicator symbol letter i",
+    "aliases": [
+      "regional_indicator_symbol_i"
+    ],
     "tags": [
       "letter",
       "i"
-    ],
-    "description": "regional indicator symbol letter i",
-    "emoji": "🇮",
-    "aliases": [
-      "regional_indicator_symbol_i"
     ]
   },
   {
+    "emojiChar": "🇯",
+    "emoji": "\uD83C\uDDEF",
+    "description": "regional indicator symbol letter j",
+    "aliases": [
+      "regional_indicator_symbol_j"
+    ],
     "tags": [
       "letter",
       "j"
-    ],
-    "description": "regional indicator symbol letter j",
-    "emoji": "🇯",
-    "aliases": [
-      "regional_indicator_symbol_j"
     ]
   },
   {
+    "emojiChar": "🇰",
+    "emoji": "\uD83C\uDDF0",
+    "description": "regional indicator symbol letter k",
+    "aliases": [
+      "regional_indicator_symbol_k"
+    ],
     "tags": [
       "letter",
       "k"
-    ],
-    "description": "regional indicator symbol letter k",
-    "emoji": "🇰",
-    "aliases": [
-      "regional_indicator_symbol_k"
     ]
   },
   {
+    "emojiChar": "🇱",
+    "emoji": "\uD83C\uDDF1",
+    "description": "regional indicator symbol letter l",
+    "aliases": [
+      "regional_indicator_symbol_l"
+    ],
     "tags": [
       "letter",
       "l"
-    ],
-    "description": "regional indicator symbol letter l",
-    "emoji": "🇱",
-    "aliases": [
-      "regional_indicator_symbol_l"
     ]
   },
   {
+    "emojiChar": "🇲",
+    "emoji": "\uD83C\uDDF2",
+    "description": "regional indicator symbol letter m",
+    "aliases": [
+      "regional_indicator_symbol_m"
+    ],
     "tags": [
       "letter",
       "m"
-    ],
-    "description": "regional indicator symbol letter m",
-    "emoji": "🇲",
-    "aliases": [
-      "regional_indicator_symbol_m"
     ]
   },
   {
+    "emojiChar": "🇳",
+    "emoji": "\uD83C\uDDF3",
+    "description": "regional indicator symbol letter n",
+    "aliases": [
+      "regional_indicator_symbol_n"
+    ],
     "tags": [
       "letter",
       "n"
-    ],
-    "description": "regional indicator symbol letter n",
-    "emoji": "🇳",
-    "aliases": [
-      "regional_indicator_symbol_n"
     ]
   },
   {
+    "emojiChar": "🇴",
+    "emoji": "\uD83C\uDDF4",
+    "description": "regional indicator symbol letter o",
+    "aliases": [
+      "regional_indicator_symbol_o"
+    ],
     "tags": [
       "letter",
       "o"
-    ],
-    "description": "regional indicator symbol letter o",
-    "emoji": "🇴",
-    "aliases": [
-      "regional_indicator_symbol_o"
     ]
   },
   {
+    "emojiChar": "🇵",
+    "emoji": "\uD83C\uDDF5",
+    "description": "regional indicator symbol letter p",
+    "aliases": [
+      "regional_indicator_symbol_p"
+    ],
     "tags": [
       "letter",
       "p"
-    ],
-    "description": "regional indicator symbol letter p",
-    "emoji": "🇵",
-    "aliases": [
-      "regional_indicator_symbol_p"
     ]
   },
   {
+    "emojiChar": "🇶",
+    "emoji": "\uD83C\uDDF6",
+    "description": "regional indicator symbol letter q",
+    "aliases": [
+      "regional_indicator_symbol_q"
+    ],
     "tags": [
       "letter",
       "q"
-    ],
-    "description": "regional indicator symbol letter q",
-    "emoji": "🇶",
-    "aliases": [
-      "regional_indicator_symbol_q"
     ]
   },
   {
+    "emojiChar": "🇷",
+    "emoji": "\uD83C\uDDF7",
+    "description": "regional indicator symbol letter r",
+    "aliases": [
+      "regional_indicator_symbol_r"
+    ],
     "tags": [
       "letter",
       "r"
-    ],
-    "description": "regional indicator symbol letter r",
-    "emoji": "🇷",
-    "aliases": [
-      "regional_indicator_symbol_r"
     ]
   },
   {
+    "emojiChar": "🇸",
+    "emoji": "\uD83C\uDDF8",
+    "description": "regional indicator symbol letter s",
+    "aliases": [
+      "regional_indicator_symbol_s"
+    ],
     "tags": [
       "letter",
       "s"
-    ],
-    "description": "regional indicator symbol letter s",
-    "emoji": "🇸",
-    "aliases": [
-      "regional_indicator_symbol_s"
     ]
   },
   {
+    "emojiChar": "🇹",
+    "emoji": "\uD83C\uDDF9",
+    "description": "regional indicator symbol letter t",
+    "aliases": [
+      "regional_indicator_symbol_t"
+    ],
     "tags": [
       "letter",
       "t"
-    ],
-    "description": "regional indicator symbol letter t",
-    "emoji": "🇹",
-    "aliases": [
-      "regional_indicator_symbol_t"
     ]
   },
   {
+    "emojiChar": "🇺",
+    "emoji": "\uD83C\uDDFA",
+    "description": "regional indicator symbol letter u",
+    "aliases": [
+      "regional_indicator_symbol_u"
+    ],
     "tags": [
       "letter",
       "u"
-    ],
-    "description": "regional indicator symbol letter u",
-    "emoji": "🇺",
-    "aliases": [
-      "regional_indicator_symbol_u"
     ]
   },
   {
+    "emojiChar": "🇻",
+    "emoji": "\uD83C\uDDFB",
+    "description": "regional indicator symbol letter v",
+    "aliases": [
+      "regional_indicator_symbol_v"
+    ],
     "tags": [
       "letter",
       "v"
-    ],
-    "description": "regional indicator symbol letter v",
-    "emoji": "🇻",
-    "aliases": [
-      "regional_indicator_symbol_v"
     ]
   },
   {
+    "emojiChar": "🇼",
+    "emoji": "\uD83C\uDDFC",
+    "description": "regional indicator symbol letter w",
+    "aliases": [
+      "regional_indicator_symbol_w"
+    ],
     "tags": [
       "letter",
       "w"
-    ],
-    "description": "regional indicator symbol letter w",
-    "emoji": "🇼",
-    "aliases": [
-      "regional_indicator_symbol_w"
     ]
   },
   {
+    "emojiChar": "🇽",
+    "emoji": "\uD83C\uDDFD",
+    "description": "regional indicator symbol letter x",
+    "aliases": [
+      "regional_indicator_symbol_x"
+    ],
     "tags": [
       "letter",
       "x"
-    ],
-    "description": "regional indicator symbol letter x",
-    "emoji": "🇽",
-    "aliases": [
-      "regional_indicator_symbol_x"
     ]
   },
   {
+    "emojiChar": "🇾",
+    "emoji": "\uD83C\uDDFE",
+    "description": "regional indicator symbol letter y",
+    "aliases": [
+      "regional_indicator_symbol_y"
+    ],
     "tags": [
       "letter",
       "y"
-    ],
-    "description": "regional indicator symbol letter y",
-    "emoji": "🇾",
-    "aliases": [
-      "regional_indicator_symbol_y"
     ]
   },
   {
+    "emojiChar": "🇿",
+    "emoji": "\uD83C\uDDFF",
+    "description": "regional indicator symbol letter z",
+    "aliases": [
+      "regional_indicator_symbol_z"
+    ],
     "tags": [
       "letter",
       "z"
-    ],
-    "description": "regional indicator symbol letter z",
-    "emoji": "🇿",
-    "aliases": [
-      "regional_indicator_symbol_z"
     ]
   },
   {
-    "emoji": "👨‍👩‍👦",
+    "emojiChar": "👨‍👩‍👦",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66",
     "description": "family (man, woman, boy)",
     "aliases": [
       "family_man_woman_boy"
@@ -10719,7 +11276,8 @@
     ]
   },
   {
-    "emoji": "👨‍👩‍👧",
+    "emojiChar": "👨‍👩‍👧",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67",
     "description": "family (man, woman, girl)",
     "aliases": [
       "family_man_woman_girl"
@@ -10732,7 +11290,8 @@
     ]
   },
   {
-    "emoji": "👨‍👩‍👦‍👦",
+    "emojiChar": "👨‍👩‍👦‍👦",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66\u200D\uD83D\uDC66",
     "description": "family (man, woman, boy, boy)",
     "aliases": [
       "family_man_woman_boy_boy"
@@ -10745,7 +11304,8 @@
     ]
   },
   {
-    "emoji": "👨‍👩‍👧‍👧",
+    "emojiChar": "👨‍👩‍👧‍👧",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67",
     "description": "family (man, woman, girl, girl)",
     "aliases": [
       "family_man_woman_girl_girl"
@@ -10758,7 +11318,8 @@
     ]
   },
   {
-    "emoji": "👨‍👩‍👧‍👦",
+    "emojiChar": "👨‍👩‍👧‍👦",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66",
     "description": "family (man, woman, girl, boy)",
     "aliases": [
       "family_man_woman_girl_boy"
@@ -10772,7 +11333,8 @@
     ]
   },
   {
-    "emoji": "👩‍👩‍👦",
+    "emojiChar": "👩‍👩‍👦",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC66",
     "description": "family (woman, woman, boy)",
     "aliases": [
       "family_woman_woman_boy"
@@ -10784,7 +11346,8 @@
     ]
   },
   {
-    "emoji": "👩‍👩‍👧",
+    "emojiChar": "👩‍👩‍👧",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67",
     "description": "family (woman, woman, girl)",
     "aliases": [
       "family_woman_woman_girl"
@@ -10796,7 +11359,8 @@
     ]
   },
   {
-    "emoji": "👩‍👩‍👧‍👦",
+    "emojiChar": "👩‍👩‍👧‍👦",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66",
     "description": "family (woman, woman, girl, boy)",
     "aliases": [
       "family_woman_woman_girl_boy"
@@ -10809,7 +11373,8 @@
     ]
   },
   {
-    "emoji": "👩‍👩‍👦‍👦",
+    "emojiChar": "👩‍👩‍👦‍👦",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC66\u200D\uD83D\uDC66",
     "description": "family (woman, woman, boy, boy)",
     "aliases": [
       "family_woman_woman_boy_boy"
@@ -10821,7 +11386,8 @@
     ]
   },
   {
-    "emoji": "👩‍👩‍👧‍👧",
+    "emojiChar": "👩‍👩‍👧‍👧",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67",
     "description": "family (woman, woman, girl, girl)",
     "aliases": [
       "family_woman_woman_girl_girl"
@@ -10833,7 +11399,8 @@
     ]
   },
   {
-    "emoji": "👨‍👨‍👦",
+    "emojiChar": "👨‍👨‍👦",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC66",
     "description": "family (man, man, boy)",
     "aliases": [
       "family_man_man_boy"
@@ -10845,7 +11412,8 @@
     ]
   },
   {
-    "emoji": "👨‍👨‍👧",
+    "emojiChar": "👨‍👨‍👧",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC67",
     "description": "family (man, man, girl)",
     "aliases": [
       "family_man_man_girl"
@@ -10857,7 +11425,8 @@
     ]
   },
   {
-    "emoji": "👨‍👨‍👧‍👦",
+    "emojiChar": "👨‍👨‍👧‍👦",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC67\u200D\uD83D\uDC66",
     "description": "family (man, man, girl, boy)",
     "aliases": [
       "family_man_man_girl_boy"
@@ -10870,7 +11439,8 @@
     ]
   },
   {
-    "emoji": "👨‍👨‍👦‍👦",
+    "emojiChar": "👨‍👨‍👦‍👦",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC66\u200D\uD83D\uDC66",
     "description": "family (man, man, boy, boy)",
     "aliases": [
       "family_man_man_boy_boy"
@@ -10882,7 +11452,8 @@
     ]
   },
   {
-    "emoji": "👨‍👨‍👧‍👧",
+    "emojiChar": "👨‍👨‍👧‍👧",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC67\u200D\uD83D\uDC67",
     "description": "family (man, man, girl, girl)",
     "aliases": [
       "family_man_man_girl_girl"
@@ -10894,7 +11465,8 @@
     ]
   },
   {
-    "emoji": "👩‍❤️‍👩",
+    "emojiChar": "👩‍❤️‍👩",
+    "emoji": "\uD83D\uDC69\u200D\u2764\uFE0F\u200D\uD83D\uDC69",
     "description": "couple with heart (woman, woman)",
     "aliases": [
       "couple_with_heart_woman_woman"
@@ -10906,7 +11478,8 @@
     ]
   },
   {
-    "emoji": "👨‍❤️‍👨",
+    "emojiChar": "👨‍❤️‍👨",
+    "emoji": "\uD83D\uDC68\u200D\u2764\uFE0F\u200D\uD83D\uDC68",
     "description": "couple with heart (man, man)",
     "aliases": [
       "couple_with_heart_man_man"
@@ -10918,7 +11491,8 @@
     ]
   },
   {
-    "emoji": "👩‍❤️‍💋‍👩",
+    "emojiChar": "👩‍❤️‍💋‍👩",
+    "emoji": "\uD83D\uDC69\u200D\u2764\uFE0F\u200D\uD83D\uDC8B\u200D\uD83D\uDC69",
     "description": "kiss (woman, woman)",
     "aliases": [
       "couplekiss_woman_woman"
@@ -10930,7 +11504,8 @@
     ]
   },
   {
-    "emoji": "👨‍❤️‍💋‍👨",
+    "emojiChar": "👨‍❤️‍💋‍👨",
+    "emoji": "\uD83D\uDC68\u200D\u2764\uFE0F\u200D\uD83D\uDC8B\u200D\uD83D\uDC68",
     "description": "kiss (man, man)",
     "aliases": [
       "couplekiss_man_man"
@@ -10942,7 +11517,8 @@
     ]
   },
   {
-    "emoji": "🖖",
+    "emojiChar": "🖖",
+    "emoji": "\uD83D\uDD96",
     "description": "raised hand with part between middle and ring fingers",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -10954,7 +11530,8 @@
     ]
   },
   {
-    "emoji": "🖕",
+    "emojiChar": "🖕",
+    "emoji": "\uD83D\uDD95",
     "description": "reversed hand with middle finger extended",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -10963,9 +11540,9 @@
     "tags": []
   },
   {
-    "emoji": "🙂",
+    "emojiChar": "🙂",
+    "emoji": "\uD83D\uDE42",
     "description": "slightly smiling face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "slightly_smiling",
       "slight_smile"
@@ -10973,9 +11550,9 @@
     "tags": []
   },
   {
-    "emoji": "🤗",
+    "emojiChar": "🤗",
+    "emoji": "\uD83E\uDD17",
     "description": "hugging face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "hugging",
       "hug",
@@ -10984,9 +11561,9 @@
     "tags": []
   },
   {
-    "emoji": "🤔",
+    "emojiChar": "🤔",
+    "emoji": "\uD83E\uDD14",
     "description": "thinking face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "thinking",
       "think",
@@ -10995,9 +11572,9 @@
     "tags": []
   },
   {
-    "emoji": "🙄",
+    "emojiChar": "🙄",
+    "emoji": "\uD83D\uDE44",
     "description": "face with rolling eyes",
-    "supports_fitzpatrick": false,
     "aliases": [
       "eye_roll",
       "rolling_eyes"
@@ -11005,9 +11582,9 @@
     "tags": []
   },
   {
-    "emoji": "🤐",
+    "emojiChar": "🤐",
+    "emoji": "\uD83E\uDD10",
     "description": "zipper-mouth face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "zipper_mouth",
       "zip_it",
@@ -11017,9 +11594,9 @@
     "tags": []
   },
   {
-    "emoji": "🤓",
+    "emojiChar": "🤓",
+    "emoji": "\uD83E\uDD13",
     "description": "nerd face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "nerd",
       "nerdy"
@@ -11027,27 +11604,27 @@
     "tags": []
   },
   {
-    "emoji": "☹",
+    "emojiChar": "☹",
+    "emoji": "\u2639",
     "description": "white frowning face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "frowning_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🙁",
+    "emojiChar": "🙁",
+    "emoji": "\uD83D\uDE41",
     "description": "slightly frowning face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "slightly_frowning"
     ],
     "tags": []
   },
   {
-    "emoji": "🙃",
+    "emojiChar": "🙃",
+    "emoji": "\uD83D\uDE43",
     "description": "upside-down face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "upside_down",
       "flipped_face"
@@ -11055,9 +11632,9 @@
     "tags": []
   },
   {
-    "emoji": "🤒",
+    "emojiChar": "🤒",
+    "emoji": "\uD83E\uDD12",
     "description": "face with thermometer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "sick",
       "ill",
@@ -11066,9 +11643,9 @@
     "tags": []
   },
   {
-    "emoji": "🤕",
+    "emojiChar": "🤕",
+    "emoji": "\uD83E\uDD15",
     "description": "face with head bandage",
-    "supports_fitzpatrick": false,
     "aliases": [
       "injured",
       "head_bandage",
@@ -11078,9 +11655,9 @@
     "tags": []
   },
   {
-    "emoji": "🤑",
+    "emojiChar": "🤑",
+    "emoji": "\uD83E\uDD11",
     "description": "money-mouth face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "money_mouth",
       "money_face"
@@ -11088,16 +11665,17 @@
     "tags": []
   },
   {
-    "emoji": "⛑",
+    "emojiChar": "⛑",
+    "emoji": "\u26D1",
     "description": "helmet with white crosse",
-    "supports_fitzpatrick": false,
     "aliases": [
       "helmet_white_cross"
     ],
     "tags": []
   },
   {
-    "emoji": "🕵",
+    "emojiChar": "🕵",
+    "emoji": "\uD83D\uDD75",
     "description": "sleuth or spy",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -11109,16 +11687,17 @@
     "tags": []
   },
   {
-    "emoji": "🗣",
+    "emojiChar": "🗣",
+    "emoji": "\uD83D\uDDE3",
     "description": "speaking head in silhouette",
-    "supports_fitzpatrick": false,
     "aliases": [
       "speaking_head_in_silhouette"
     ],
     "tags": []
   },
   {
-    "emoji": "🕴",
+    "emojiChar": "🕴",
+    "emoji": "\uD83D\uDD74",
     "description": "man in business suit levitating",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -11128,7 +11707,8 @@
     "tags": []
   },
   {
-    "emoji": "🤘",
+    "emojiChar": "🤘",
+    "emoji": "\uD83E\uDD18",
     "description": "sign of the horns",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -11140,7 +11720,8 @@
     "tags": []
   },
   {
-    "emoji": "🖐",
+    "emojiChar": "🖐",
+    "emoji": "\uD83D\uDD90",
     "description": "raised hand with five fingers splayed",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -11150,7 +11731,8 @@
     "tags": []
   },
   {
-    "emoji": "✍",
+    "emojiChar": "✍",
+    "emoji": "\u270D",
     "description": "writing hand",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -11160,36 +11742,36 @@
     "tags": []
   },
   {
-    "emoji": "👁",
+    "emojiChar": "👁",
+    "emoji": "\uD83D\uDC41",
     "description": "eye",
-    "supports_fitzpatrick": false,
     "aliases": [
       "eye"
     ],
     "tags": []
   },
   {
-    "emoji": "❣",
+    "emojiChar": "❣",
+    "emoji": "\u2763",
     "description": "heavy heart exclamation mark ornament",
-    "supports_fitzpatrick": false,
     "aliases": [
       "exclamation_heart"
     ],
     "tags": []
   },
   {
-    "emoji": "🕳",
+    "emojiChar": "🕳",
+    "emoji": "\uD83D\uDD73",
     "description": "hole",
-    "supports_fitzpatrick": false,
     "aliases": [
       "hole"
     ],
     "tags": []
   },
   {
-    "emoji": "🗯",
+    "emojiChar": "🗯",
+    "emoji": "\uD83D\uDDEF",
     "description": "right anger bubble",
-    "supports_fitzpatrick": false,
     "aliases": [
       "right_anger_bubble",
       "zig_zag_bubble"
@@ -11197,27 +11779,27 @@
     "tags": []
   },
   {
-    "emoji": "🕶",
+    "emojiChar": "🕶",
+    "emoji": "\uD83D\uDD76",
     "description": "dark sunglasses",
-    "supports_fitzpatrick": false,
     "aliases": [
       "dark_sunglasses"
     ],
     "tags": []
   },
   {
-    "emoji": "🛍",
+    "emojiChar": "🛍",
+    "emoji": "\uD83D\uDECD",
     "description": "shopping bags",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shopping_bags"
     ],
     "tags": []
   },
   {
-    "emoji": "📿",
+    "emojiChar": "📿",
+    "emoji": "\uD83D\uDCFF",
     "description": "prayer beads",
-    "supports_fitzpatrick": false,
     "aliases": [
       "prayer_beads",
       "dhikr_beads",
@@ -11226,18 +11808,18 @@
     "tags": []
   },
   {
-    "emoji": "☠",
+    "emojiChar": "☠",
+    "emoji": "\u2620",
     "description": "skull and crossbones",
-    "supports_fitzpatrick": false,
     "aliases": [
       "skull_crossbones"
     ],
     "tags": []
   },
   {
-    "emoji": "🤖",
+    "emojiChar": "🤖",
+    "emoji": "\uD83E\uDD16",
     "description": "robot face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "robot_face",
       "bot_face"
@@ -11245,9 +11827,9 @@
     "tags": []
   },
   {
-    "emoji": "🦁",
+    "emojiChar": "🦁",
+    "emoji": "\uD83E\uDD81",
     "description": "lion face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lion_face",
       "cute_lion",
@@ -11256,18 +11838,18 @@
     "tags": []
   },
   {
-    "emoji": "🦄",
+    "emojiChar": "🦄",
+    "emoji": "\uD83E\uDD84",
     "description": "unicorn face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "unicorn_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🐿",
+    "emojiChar": "🐿",
+    "emoji": "\uD83D\uDC3F",
     "description": "chipmunk",
-    "supports_fitzpatrick": false,
     "aliases": [
       "chipmunk",
       "squirrel"
@@ -11275,18 +11857,18 @@
     "tags": []
   },
   {
-    "emoji": "🦃",
+    "emojiChar": "🦃",
+    "emoji": "\uD83E\uDD83",
     "description": "turkey",
-    "supports_fitzpatrick": false,
     "aliases": [
       "turkey"
     ],
     "tags": []
   },
   {
-    "emoji": "🕊",
+    "emojiChar": "🕊",
+    "emoji": "\uD83D\uDD4A",
     "description": "dove of peace, carrying an olive branch",
-    "supports_fitzpatrick": false,
     "aliases": [
       "dove",
       "dove_peace"
@@ -11294,27 +11876,27 @@
     "tags": []
   },
   {
-    "emoji": "🦀",
+    "emojiChar": "🦀",
+    "emoji": "\uD83E\uDD80",
     "description": "red crab",
-    "supports_fitzpatrick": false,
     "aliases": [
       "crab"
     ],
     "tags": []
   },
   {
-    "emoji": "🕷",
+    "emojiChar": "🕷",
+    "emoji": "\uD83D\uDD77",
     "description": "black spider with eight legs",
-    "supports_fitzpatrick": false,
     "aliases": [
       "spider"
     ],
     "tags": []
   },
   {
-    "emoji": "🕸",
+    "emojiChar": "🕸",
+    "emoji": "\uD83D\uDD78",
     "description": "spider web in orb form",
-    "supports_fitzpatrick": false,
     "aliases": [
       "spider_web",
       "cobweb"
@@ -11322,27 +11904,27 @@
     "tags": []
   },
   {
-    "emoji": "🦂",
+    "emojiChar": "🦂",
+    "emoji": "\uD83E\uDD82",
     "description": "scorpion",
-    "supports_fitzpatrick": false,
     "aliases": [
       "scorpion"
     ],
     "tags": []
   },
   {
-    "emoji": "🏵",
+    "emojiChar": "🏵",
+    "emoji": "\uD83C\uDFF5",
     "description": "rosette",
-    "supports_fitzpatrick": false,
     "aliases": [
       "rosette"
     ],
     "tags": []
   },
   {
-    "emoji": "☘",
+    "emojiChar": "☘",
+    "emoji": "\u2618",
     "description": "shamrock",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shamrock",
       "st_patrick"
@@ -11350,9 +11932,9 @@
     "tags": []
   },
   {
-    "emoji": "🌶",
+    "emojiChar": "🌶",
+    "emoji": "\uD83C\uDF36",
     "description": "hot pepper",
-    "supports_fitzpatrick": false,
     "aliases": [
       "hot_pepper",
       "chili_pepper",
@@ -11362,36 +11944,36 @@
     "tags": []
   },
   {
-    "emoji": "🧀",
+    "emojiChar": "🧀",
+    "emoji": "\uD83E\uDDC0",
     "description": "cheese wedge",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cheese"
     ],
     "tags": []
   },
   {
-    "emoji": "🌭",
+    "emojiChar": "🌭",
+    "emoji": "\uD83C\uDF2D",
     "description": "hot dog",
-    "supports_fitzpatrick": false,
     "aliases": [
       "hot_dog"
     ],
     "tags": []
   },
   {
-    "emoji": "🌮",
+    "emojiChar": "🌮",
+    "emoji": "\uD83C\uDF2E",
     "description": "taco",
-    "supports_fitzpatrick": false,
     "aliases": [
       "taco"
     ],
     "tags": []
   },
   {
-    "emoji": "🌯",
+    "emojiChar": "🌯",
+    "emoji": "\uD83C\uDF2F",
     "description": "burrito",
-    "supports_fitzpatrick": false,
     "aliases": [
       "burrito",
       "wrap"
@@ -11399,18 +11981,18 @@
     "tags": []
   },
   {
-    "emoji": "🍿",
+    "emojiChar": "🍿",
+    "emoji": "\uD83C\uDF7F",
     "description": "popcorn",
-    "supports_fitzpatrick": false,
     "aliases": [
       "popcorn"
     ],
     "tags": []
   },
   {
-    "emoji": "🍾",
+    "emojiChar": "🍾",
+    "emoji": "\uD83C\uDF7E",
     "description": "bottle with popping cork",
-    "supports_fitzpatrick": false,
     "aliases": [
       "champagne",
       "sparkling_wine"
@@ -11418,18 +12000,18 @@
     "tags": []
   },
   {
-    "emoji": "🍽",
+    "emojiChar": "🍽",
+    "emoji": "\uD83C\uDF7D",
     "description": "fork and knife with plate",
-    "supports_fitzpatrick": false,
     "aliases": [
       "fork_knife_plate"
     ],
     "tags": []
   },
   {
-    "emoji": "🏺",
+    "emojiChar": "🏺",
+    "emoji": "\uD83C\uDFFA",
     "description": "amphora",
-    "supports_fitzpatrick": false,
     "aliases": [
       "amphora",
       "jar",
@@ -11438,18 +12020,18 @@
     "tags": []
   },
   {
-    "emoji": "🗺",
+    "emojiChar": "🗺",
+    "emoji": "\uD83D\uDDFA",
     "description": "world map",
-    "supports_fitzpatrick": false,
     "aliases": [
       "world_map"
     ],
     "tags": []
   },
   {
-    "emoji": "🏔",
+    "emojiChar": "🏔",
+    "emoji": "\uD83C\uDFD4",
     "description": "snow capped mountain",
-    "supports_fitzpatrick": false,
     "aliases": [
       "snow_capped_mountain",
       "mont_fuji"
@@ -11457,18 +12039,18 @@
     "tags": []
   },
   {
-    "emoji": "⛰",
+    "emojiChar": "⛰",
+    "emoji": "\u26F0",
     "description": "mountain",
-    "supports_fitzpatrick": false,
     "aliases": [
       "mountain"
     ],
     "tags": []
   },
   {
-    "emoji": "🏕",
+    "emojiChar": "🏕",
+    "emoji": "\uD83C\uDFD5",
     "description": "camping with tent and tree",
-    "supports_fitzpatrick": false,
     "aliases": [
       "camping",
       "campsite"
@@ -11476,63 +12058,63 @@
     "tags": []
   },
   {
-    "emoji": "🏖",
+    "emojiChar": "🏖",
+    "emoji": "\uD83C\uDFD6",
     "description": "beach with umbrella",
-    "supports_fitzpatrick": false,
     "aliases": [
       "breach"
     ],
     "tags": []
   },
   {
-    "emoji": "🏜",
+    "emojiChar": "🏜",
+    "emoji": "\uD83C\uDFDC",
     "description": "desert with cactus",
-    "supports_fitzpatrick": false,
     "aliases": [
       "desert"
     ],
     "tags": []
   },
   {
-    "emoji": "🏝",
+    "emojiChar": "🏝",
+    "emoji": "\uD83C\uDFDD",
     "description": "desert island with palm tree",
-    "supports_fitzpatrick": false,
     "aliases": [
       "desert_island"
     ],
     "tags": []
   },
   {
-    "emoji": "🏞",
+    "emojiChar": "🏞",
+    "emoji": "\uD83C\uDFDE",
     "description": "national park",
-    "supports_fitzpatrick": false,
     "aliases": [
       "national_park"
     ],
     "tags": []
   },
   {
-    "emoji": "🏟",
+    "emojiChar": "🏟",
+    "emoji": "\uD83C\uDFDF",
     "description": "stadium",
-    "supports_fitzpatrick": false,
     "aliases": [
       "stadium"
     ],
     "tags": []
   },
   {
-    "emoji": "🏛",
+    "emojiChar": "🏛",
+    "emoji": "\uD83C\uDFDB",
     "description": "classical building",
-    "supports_fitzpatrick": false,
     "aliases": [
       "classical_building"
     ],
     "tags": []
   },
   {
-    "emoji": "🏗",
+    "emojiChar": "🏗",
+    "emoji": "\uD83C\uDFD7",
     "description": "building in construction with crane",
-    "supports_fitzpatrick": false,
     "aliases": [
       "building_construction",
       "crane"
@@ -11540,9 +12122,9 @@
     "tags": []
   },
   {
-    "emoji": "🏘",
+    "emojiChar": "🏘",
+    "emoji": "\uD83C\uDFD8",
     "description": "house buildings",
-    "supports_fitzpatrick": false,
     "aliases": [
       "house_buildings",
       "multiple_houses"
@@ -11550,18 +12132,18 @@
     "tags": []
   },
   {
-    "emoji": "🏙",
+    "emojiChar": "🏙",
+    "emoji": "\uD83C\uDFD9",
     "description": "cityscape",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cityscape"
     ],
     "tags": []
   },
   {
-    "emoji": "🏚",
+    "emojiChar": "🏚",
+    "emoji": "\uD83C\uDFDA",
     "description": "derelict house",
-    "supports_fitzpatrick": false,
     "aliases": [
       "derelict_house",
       "old_house",
@@ -11570,9 +12152,9 @@
     "tags": []
   },
   {
-    "emoji": "🛐",
+    "emojiChar": "🛐",
+    "emoji": "\uD83D\uDED0",
     "description": "place of worship",
-    "supports_fitzpatrick": false,
     "aliases": [
       "worship_building",
       "worship_place",
@@ -11582,9 +12164,9 @@
     "tags": []
   },
   {
-    "emoji": "🕋",
+    "emojiChar": "🕋",
+    "emoji": "\uD83D\uDD4B",
     "description": "kaaba",
-    "supports_fitzpatrick": false,
     "aliases": [
       "kaaba",
       "mecca"
@@ -11592,9 +12174,9 @@
     "tags": []
   },
   {
-    "emoji": "🕌",
+    "emojiChar": "🕌",
+    "emoji": "\uD83D\uDD4C",
     "description": "mosque with domed roof and minaret",
-    "supports_fitzpatrick": false,
     "aliases": [
       "mosque",
       "minaret",
@@ -11603,9 +12185,9 @@
     "tags": []
   },
   {
-    "emoji": "🕍",
+    "emojiChar": "🕍",
+    "emoji": "\uD83D\uDD4D",
     "description": "synagogue with star of David",
-    "supports_fitzpatrick": false,
     "aliases": [
       "synagogue",
       "temple",
@@ -11614,9 +12196,9 @@
     "tags": []
   },
   {
-    "emoji": "🖼",
+    "emojiChar": "🖼",
+    "emoji": "\uD83D\uDDBC",
     "description": "frame with picture or painting",
-    "supports_fitzpatrick": false,
     "aliases": [
       "picture_frame",
       "painting",
@@ -11625,18 +12207,18 @@
     "tags": []
   },
   {
-    "emoji": "🛢",
+    "emojiChar": "🛢",
+    "emoji": "\uD83D\uDEE2",
     "description": "oil drum",
-    "supports_fitzpatrick": false,
     "aliases": [
       "oil_drum"
     ],
     "tags": []
   },
   {
-    "emoji": "🛣",
+    "emojiChar": "🛣",
+    "emoji": "\uD83D\uDEE3",
     "description": "motorway",
-    "supports_fitzpatrick": false,
     "aliases": [
       "motorway",
       "highway",
@@ -11647,54 +12229,54 @@
     "tags": []
   },
   {
-    "emoji": "🛤",
+    "emojiChar": "🛤",
+    "emoji": "\uD83D\uDEE4",
     "description": "railway track",
-    "supports_fitzpatrick": false,
     "aliases": [
       "railway_track"
     ],
     "tags": []
   },
   {
-    "emoji": "🛳",
+    "emojiChar": "🛳",
+    "emoji": "\uD83D\uDEF3",
     "description": "passenger ship",
-    "supports_fitzpatrick": false,
     "aliases": [
       "passenger_ship"
     ],
     "tags": []
   },
   {
-    "emoji": "⛴",
+    "emojiChar": "⛴",
+    "emoji": "\u26F4",
     "description": "ferry",
-    "supports_fitzpatrick": false,
     "aliases": [
       "ferry"
     ],
     "tags": []
   },
   {
-    "emoji": "🛥",
+    "emojiChar": "🛥",
+    "emoji": "\uD83D\uDEE5",
     "description": "motor boat",
-    "supports_fitzpatrick": false,
     "aliases": [
       "motor_boat"
     ],
     "tags": []
   },
   {
-    "emoji": "🛩",
+    "emojiChar": "🛩",
+    "emoji": "\uD83D\uDEE9",
     "description": "small airplane",
-    "supports_fitzpatrick": false,
     "aliases": [
       "small_airplane"
     ],
     "tags": []
   },
   {
-    "emoji": "🛫",
+    "emojiChar": "🛫",
+    "emoji": "\uD83D\uDEEB",
     "description": "airplane departure",
-    "supports_fitzpatrick": false,
     "aliases": [
       "airplane_departure",
       "take_off"
@@ -11702,9 +12284,9 @@
     "tags": []
   },
   {
-    "emoji": "🛬",
+    "emojiChar": "🛬",
+    "emoji": "\uD83D\uDEEC",
     "description": "airplane arriving",
-    "supports_fitzpatrick": false,
     "aliases": [
       "airplane_arriving",
       "airplane_arrival",
@@ -11713,25 +12295,26 @@
     "tags": []
   },
   {
-    "emoji": "🛰",
+    "emojiChar": "🛰",
+    "emoji": "\uD83D\uDEF0",
     "description": "satellite",
-    "supports_fitzpatrick": false,
     "aliases": [
       "satellite"
     ],
     "tags": []
   },
   {
-    "emoji": "🛎",
+    "emojiChar": "🛎",
+    "emoji": "\uD83D\uDECE",
     "description": "bellhop bell",
-    "supports_fitzpatrick": false,
     "aliases": [
       "bellhop_bell"
     ],
     "tags": []
   },
   {
-    "emoji": "🛌",
+    "emojiChar": "🛌",
+    "emoji": "\uD83D\uDECC",
     "description": "sleeping accommodation",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -11740,9 +12323,9 @@
     "tags": []
   },
   {
-    "emoji": "🛏",
+    "emojiChar": "🛏",
+    "emoji": "\uD83D\uDECF",
     "description": "bed or bedroom",
-    "supports_fitzpatrick": false,
     "aliases": [
       "bed",
       "bedroom"
@@ -11750,9 +12333,9 @@
     "tags": []
   },
   {
-    "emoji": "🛋",
+    "emojiChar": "🛋",
+    "emoji": "\uD83D\uDECB",
     "description": "couch and lamp",
-    "supports_fitzpatrick": false,
     "aliases": [
       "couch_lamp",
       "couch",
@@ -11762,36 +12345,36 @@
     "tags": []
   },
   {
-    "emoji": "⏱",
+    "emojiChar": "⏱",
+    "emoji": "\u23F1",
     "description": "stopwatch",
-    "supports_fitzpatrick": false,
     "aliases": [
       "stopwatch"
     ],
     "tags": []
   },
   {
-    "emoji": "⏲",
+    "emojiChar": "⏲",
+    "emoji": "\u23F2",
     "description": "timer clock",
-    "supports_fitzpatrick": false,
     "aliases": [
       "timer_clock"
     ],
     "tags": []
   },
   {
-    "emoji": "🕰",
+    "emojiChar": "🕰",
+    "emoji": "\uD83D\uDD70",
     "description": "mantelpiece clock",
-    "supports_fitzpatrick": false,
     "aliases": [
       "mantelpiece_clock"
     ],
     "tags": []
   },
   {
-    "emoji": "🌡",
+    "emojiChar": "🌡",
+    "emoji": "\uD83C\uDF21",
     "description": "thermometer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "thermometer",
       "hot_weather",
@@ -11800,90 +12383,90 @@
     "tags": []
   },
   {
-    "emoji": "⛈",
+    "emojiChar": "⛈",
+    "emoji": "\u26C8",
     "description": "thunder cloud and rain",
-    "supports_fitzpatrick": false,
     "aliases": [
       "thunder_cloud_rain"
     ],
     "tags": []
   },
   {
-    "emoji": "🌤",
+    "emojiChar": "🌤",
+    "emoji": "\uD83C\uDF24",
     "description": "white sun with small cloud",
-    "supports_fitzpatrick": false,
     "aliases": [
       "white_sun_small_cloud"
     ],
     "tags": []
   },
   {
-    "emoji": "🌥",
+    "emojiChar": "🌥",
+    "emoji": "\uD83C\uDF25",
     "description": "white sun behind cloud",
-    "supports_fitzpatrick": false,
     "aliases": [
       "white_sun_behind_cloud"
     ],
     "tags": []
   },
   {
-    "emoji": "🌦",
+    "emojiChar": "🌦",
+    "emoji": "\uD83C\uDF26",
     "description": "white sun behind cloud with rain",
-    "supports_fitzpatrick": false,
     "aliases": [
       "white_sun_behind_cloud_rain"
     ],
     "tags": []
   },
   {
-    "emoji": "🌧",
+    "emojiChar": "🌧",
+    "emoji": "\uD83C\uDF27",
     "description": "cloud with rain",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cloud_rain"
     ],
     "tags": []
   },
   {
-    "emoji": "🌨",
+    "emojiChar": "🌨",
+    "emoji": "\uD83C\uDF28",
     "description": "cloud with snow",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cloud_snow"
     ],
     "tags": []
   },
   {
-    "emoji": "🌩",
+    "emojiChar": "🌩",
+    "emoji": "\uD83C\uDF29",
     "description": "cloud with lightning",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cloud_lightning"
     ],
     "tags": []
   },
   {
-    "emoji": "🌪",
+    "emojiChar": "🌪",
+    "emoji": "\uD83C\uDF2A",
     "description": "cloud with tornado",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cloud_tornado"
     ],
     "tags": []
   },
   {
-    "emoji": "🌫",
+    "emojiChar": "🌫",
+    "emoji": "\uD83C\uDF2B",
     "description": "fog",
-    "supports_fitzpatrick": false,
     "aliases": [
       "fog"
     ],
     "tags": []
   },
   {
-    "emoji": "🌬",
+    "emojiChar": "🌬",
+    "emoji": "\uD83C\uDF2C",
     "description": "wind blowing face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "wind_blowing_face",
       "mother_nature",
@@ -11892,18 +12475,18 @@
     "tags": []
   },
   {
-    "emoji": "☂",
+    "emojiChar": "☂",
+    "emoji": "\u2602",
     "description": "open umbrella",
-    "supports_fitzpatrick": false,
     "aliases": [
       "open_umbrella"
     ],
     "tags": []
   },
   {
-    "emoji": "⛱",
+    "emojiChar": "⛱",
+    "emoji": "\u26F1",
     "description": "umbrella planted on the ground",
-    "supports_fitzpatrick": false,
     "aliases": [
       "planted_umbrella",
       "umbrella_on_ground"
@@ -11911,9 +12494,9 @@
     "tags": []
   },
   {
-    "emoji": "☃",
+    "emojiChar": "☃",
+    "emoji": "\u2603",
     "description": "snowman with snow",
-    "supports_fitzpatrick": false,
     "aliases": [
       "snowman_with_snow",
       "snowing_snowman"
@@ -11921,9 +12504,9 @@
     "tags": []
   },
   {
-    "emoji": "☄",
+    "emojiChar": "☄",
+    "emoji": "\u2604",
     "description": "comet",
-    "supports_fitzpatrick": false,
     "aliases": [
       "comet",
       "light_beam",
@@ -11932,9 +12515,9 @@
     "tags": []
   },
   {
-    "emoji": "🕎",
+    "emojiChar": "🕎",
+    "emoji": "\uD83D\uDD4E",
     "description": "menorah with nine branches",
-    "supports_fitzpatrick": false,
     "aliases": [
       "menorah",
       "candelabrum",
@@ -11943,9 +12526,9 @@
     "tags": []
   },
   {
-    "emoji": "🎖",
+    "emojiChar": "🎖",
+    "emoji": "\uD83C\uDF96",
     "description": "military medal with ribbon",
-    "supports_fitzpatrick": false,
     "aliases": [
       "military_medal",
       "military_decoration"
@@ -11953,9 +12536,9 @@
     "tags": []
   },
   {
-    "emoji": "🎗",
+    "emojiChar": "🎗",
+    "emoji": "\uD83C\uDF97",
     "description": "reminder ribbon",
-    "supports_fitzpatrick": false,
     "aliases": [
       "reminder_ribbon",
       "awareness_ribbon"
@@ -11963,34 +12546,35 @@
     "tags": []
   },
   {
-    "emoji": "🎞",
+    "emojiChar": "🎞",
+    "emoji": "\uD83C\uDF9E",
     "description": "film frames",
-    "supports_fitzpatrick": false,
     "aliases": [
       "film_frames"
     ],
     "tags": []
   },
   {
-    "emoji": "🎟",
+    "emojiChar": "🎟",
+    "emoji": "\uD83C\uDF9F",
     "description": "admission ticket",
-    "supports_fitzpatrick": false,
     "aliases": [
       "admission_ticket"
     ],
     "tags": []
   },
   {
-    "emoji": "🏷",
+    "emojiChar": "🏷",
+    "emoji": "\uD83C\uDFF7",
     "description": "label",
-    "supports_fitzpatrick": false,
     "aliases": [
       "label"
     ],
     "tags": []
   },
   {
-    "emoji": "🏌",
+    "emojiChar": "🏌",
+    "emoji": "\uD83C\uDFCC",
     "description": "golfer swinging a golf club",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12000,7 +12584,8 @@
     "tags": []
   },
   {
-    "emoji": "🏌️‍♂️",
+    "emojiChar": "🏌️‍♂️",
+    "emoji": "\uD83C\uDFCC\uFE0F\u200D\u2642\uFE0F",
     "description": "man golfing",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12012,7 +12597,8 @@
     "tags": []
   },
   {
-    "emoji": "🏌️‍♀️",
+    "emojiChar": "🏌️‍♀️",
+    "emoji": "\uD83C\uDFCC\uFE0F\u200D\u2640\uFE0F",
     "description": "woman golfing",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12024,9 +12610,9 @@
     "tags": []
   },
   {
-    "emoji": "⛸",
+    "emojiChar": "⛸",
+    "emoji": "\u26F8",
     "description": "single ice skate",
-    "supports_fitzpatrick": false,
     "aliases": [
       "ice_skate",
       "ice_skating"
@@ -12034,16 +12620,17 @@
     "tags": []
   },
   {
-    "emoji": "⛷",
+    "emojiChar": "⛷",
+    "emoji": "\u26F7",
     "description": "skier",
-    "supports_fitzpatrick": false,
     "aliases": [
       "skier"
     ],
     "tags": []
   },
   {
-    "emoji": "⛹",
+    "emojiChar": "⛹",
+    "emoji": "\u26F9",
     "description": "person with ball",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12052,7 +12639,8 @@
     "tags": []
   },
   {
-    "emoji": "🏋",
+    "emojiChar": "🏋",
+    "emoji": "\uD83C\uDFCB",
     "description": "weight lifter",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12061,9 +12649,9 @@
     "tags": []
   },
   {
-    "emoji": "🏎",
+    "emojiChar": "🏎",
+    "emoji": "\uD83C\uDFCE",
     "description": "racing car",
-    "supports_fitzpatrick": false,
     "aliases": [
       "racing_car",
       "formula_one",
@@ -12072,9 +12660,9 @@
     "tags": []
   },
   {
-    "emoji": "🏍",
+    "emojiChar": "🏍",
+    "emoji": "\uD83C\uDFCD",
     "description": "racing motorcycle",
-    "supports_fitzpatrick": false,
     "aliases": [
       "racing_motorcycle",
       "motorcycle",
@@ -12083,9 +12671,9 @@
     "tags": []
   },
   {
-    "emoji": "🏅",
+    "emojiChar": "🏅",
+    "emoji": "\uD83C\uDFC5",
     "description": "sports medal",
-    "supports_fitzpatrick": false,
     "aliases": [
       "sports_medal",
       "sports_decoration"
@@ -12093,45 +12681,45 @@
     "tags": []
   },
   {
-    "emoji": "🏏",
+    "emojiChar": "🏏",
+    "emoji": "\uD83C\uDFCF",
     "description": "cricket bat and ball",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cricket"
     ],
     "tags": []
   },
   {
-    "emoji": "🏐",
+    "emojiChar": "🏐",
+    "emoji": "\uD83C\uDFD0",
     "description": "volleyball",
-    "supports_fitzpatrick": false,
     "aliases": [
       "volleyball"
     ],
     "tags": []
   },
   {
-    "emoji": "🏑",
+    "emojiChar": "🏑",
+    "emoji": "\uD83C\uDFD1",
     "description": "field hockey stick and ball",
-    "supports_fitzpatrick": false,
     "aliases": [
       "field_hockey"
     ],
     "tags": []
   },
   {
-    "emoji": "🏒",
+    "emojiChar": "🏒",
+    "emoji": "\uD83C\uDFD2",
     "description": "ice hockey stick and puck",
-    "supports_fitzpatrick": false,
     "aliases": [
       "ice_hockey"
     ],
     "tags": []
   },
   {
-    "emoji": "🏓",
+    "emojiChar": "🏓",
+    "emoji": "\uD83C\uDFD3",
     "description": "table tennis paddle and ball",
-    "supports_fitzpatrick": false,
     "aliases": [
       "table_tennis",
       "ping_pong"
@@ -12139,108 +12727,108 @@
     "tags": []
   },
   {
-    "emoji": "🏸",
+    "emojiChar": "🏸",
+    "emoji": "\uD83C\uDFF8",
     "description": "badminton racket and shuttlecock",
-    "supports_fitzpatrick": false,
     "aliases": [
       "badminton"
     ],
     "tags": []
   },
   {
-    "emoji": "🕹",
+    "emojiChar": "🕹",
+    "emoji": "\uD83D\uDD79",
     "description": "joystick",
-    "supports_fitzpatrick": false,
     "aliases": [
       "joystick"
     ],
     "tags": []
   },
   {
-    "emoji": "⏭",
+    "emojiChar": "⏭",
+    "emoji": "\u23ED",
     "description": "black right-pointing double triangle with vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
       "black_right_pointing_double_triangle_with_vertical_bar"
     ],
     "tags": []
   },
   {
-    "emoji": "⏯",
+    "emojiChar": "⏯",
+    "emoji": "\u23EF",
     "description": "black right-pointing triangle with double vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
       "black_right_pointing_triangle_with_double_vertical_bar"
     ],
     "tags": []
   },
   {
-    "emoji": "⏮",
+    "emojiChar": "⏮",
+    "emoji": "\u23EE",
     "description": "black left-pointing double triangle with vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
       "black_left_pointing_double_triangle_with_vertical_bar"
     ],
     "tags": []
   },
   {
-    "emoji": "⏸",
+    "emojiChar": "⏸",
+    "emoji": "\u23F8",
     "description": "double vertical bar",
-    "supports_fitzpatrick": false,
     "aliases": [
       "double_vertical_bar"
     ],
     "tags": []
   },
   {
-    "emoji": "⏹",
+    "emojiChar": "⏹",
+    "emoji": "\u23F9",
     "description": "black square for stop",
-    "supports_fitzpatrick": false,
     "aliases": [
       "black_square_for_stop"
     ],
     "tags": []
   },
   {
-    "emoji": "⏺",
+    "emojiChar": "⏺",
+    "emoji": "\u23FA",
     "description": "black circle for record",
-    "supports_fitzpatrick": false,
     "aliases": [
       "black_circle_for_record"
     ],
     "tags": []
   },
   {
-    "emoji": "🎙",
+    "emojiChar": "🎙",
+    "emoji": "\uD83C\uDF99",
     "description": "studio microphone",
-    "supports_fitzpatrick": false,
     "aliases": [
       "studio_microphone"
     ],
     "tags": []
   },
   {
-    "emoji": "🎚",
+    "emojiChar": "🎚",
+    "emoji": "\uD83C\uDF9A",
     "description": "level slider",
-    "supports_fitzpatrick": false,
     "aliases": [
       "level_slider"
     ],
     "tags": []
   },
   {
-    "emoji": "🎛",
+    "emojiChar": "🎛",
+    "emoji": "\uD83C\uDF9B",
     "description": "control knobs",
-    "supports_fitzpatrick": false,
     "aliases": [
       "control_knobs"
     ],
     "tags": []
   },
   {
-    "emoji": "*⃣",
+    "emojiChar": "*⃣",
+    "emoji": "*\u20E3",
     "description": "keycap asterisk",
-    "supports_fitzpatrick": false,
     "aliases": [
       "keycap_asterisk",
       "star_keycap"
@@ -12248,9 +12836,9 @@
     "tags": []
   },
   {
-    "emoji": "🖥",
+    "emojiChar": "🖥",
+    "emoji": "\uD83D\uDDA5",
     "description": "desktop computer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "desktop_computer",
       "pc_tower",
@@ -12259,27 +12847,27 @@
     "tags": []
   },
   {
-    "emoji": "🖨",
+    "emojiChar": "🖨",
+    "emoji": "\uD83D\uDDA8",
     "description": "printer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "printer"
     ],
     "tags": []
   },
   {
-    "emoji": "⌨",
+    "emojiChar": "⌨",
+    "emoji": "\u2328",
     "description": "keyboard",
-    "supports_fitzpatrick": false,
     "aliases": [
       "keyboard"
     ],
     "tags": []
   },
   {
-    "emoji": "🖱",
+    "emojiChar": "🖱",
+    "emoji": "\uD83D\uDDB1",
     "description": "three button mouse",
-    "supports_fitzpatrick": false,
     "aliases": [
       "computer_mouse",
       "three_button_mouse"
@@ -12287,45 +12875,45 @@
     "tags": []
   },
   {
-    "emoji": "🖲",
+    "emojiChar": "🖲",
+    "emoji": "\uD83D\uDDB2",
     "description": "trackball",
-    "supports_fitzpatrick": false,
     "aliases": [
       "trackball"
     ],
     "tags": []
   },
   {
-    "emoji": "📽",
+    "emojiChar": "📽",
+    "emoji": "\uD83D\uDCFD",
     "description": "film projector",
-    "supports_fitzpatrick": false,
     "aliases": [
       "film_projector"
     ],
     "tags": []
   },
   {
-    "emoji": "📸",
+    "emojiChar": "📸",
+    "emoji": "\uD83D\uDCF8",
     "description": "camera with flash",
-    "supports_fitzpatrick": false,
     "aliases": [
       "camera_flash"
     ],
     "tags": []
   },
   {
-    "emoji": "🕯",
+    "emojiChar": "🕯",
+    "emoji": "\uD83D\uDD6F",
     "description": "candle burning",
-    "supports_fitzpatrick": false,
     "aliases": [
       "candle"
     ],
     "tags": []
   },
   {
-    "emoji": "🗞",
+    "emojiChar": "🗞",
+    "emoji": "\uD83D\uDDDE",
     "description": "newspaper rolled up for delivery",
-    "supports_fitzpatrick": false,
     "aliases": [
       "rolled_up_newspaper",
       "newspaper_delivery"
@@ -12333,9 +12921,9 @@
     "tags": []
   },
   {
-    "emoji": "🗳",
+    "emojiChar": "🗳",
+    "emoji": "\uD83D\uDDF3",
     "description": "ballot bow with ballot",
-    "supports_fitzpatrick": false,
     "aliases": [
       "ballot",
       "ballot_box"
@@ -12343,171 +12931,171 @@
     "tags": []
   },
   {
-    "emoji": "🖋",
+    "emojiChar": "🖋",
+    "emoji": "\uD83D\uDD8B",
     "description": "lower left fountain pen",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lower_left_fountain_pen"
     ],
     "tags": []
   },
   {
-    "emoji": "🖊",
+    "emojiChar": "🖊",
+    "emoji": "\uD83D\uDD8A",
     "description": "lower left ballpoint pen",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lower_left_ballpoint_pen"
     ],
     "tags": []
   },
   {
-    "emoji": "🖌",
+    "emojiChar": "🖌",
+    "emoji": "\uD83D\uDD8C",
     "description": "lower left paintbrush",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lower_left_paintbrush"
     ],
     "tags": []
   },
   {
-    "emoji": "🖍",
+    "emojiChar": "🖍",
+    "emoji": "\uD83D\uDD8D",
     "description": "lower left crayon",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lower_left_crayon"
     ],
     "tags": []
   },
   {
-    "emoji": "🗂",
+    "emojiChar": "🗂",
+    "emoji": "\uD83D\uDDC2",
     "description": "card index dividers",
-    "supports_fitzpatrick": false,
     "aliases": [
       "card_index_dividers"
     ],
     "tags": []
   },
   {
-    "emoji": "🗒",
+    "emojiChar": "🗒",
+    "emoji": "\uD83D\uDDD2",
     "description": "spiral note pad",
-    "supports_fitzpatrick": false,
     "aliases": [
       "spiral_note_pad"
     ],
     "tags": []
   },
   {
-    "emoji": "🗓",
+    "emojiChar": "🗓",
+    "emoji": "\uD83D\uDDD3",
     "description": "spiral calendar pad",
-    "supports_fitzpatrick": false,
     "aliases": [
       "spiral_calendar_pad"
     ],
     "tags": []
   },
   {
-    "emoji": "🖇",
+    "emojiChar": "🖇",
+    "emoji": "\uD83D\uDD87",
     "description": "multiple paperclips linked together",
-    "supports_fitzpatrick": false,
     "aliases": [
       "linked_paperclips"
     ],
     "tags": []
   },
   {
-    "emoji": "🗃",
+    "emojiChar": "🗃",
+    "emoji": "\uD83D\uDDC3",
     "description": "card file box",
-    "supports_fitzpatrick": false,
     "aliases": [
       "card_file_box"
     ],
     "tags": []
   },
   {
-    "emoji": "🗄",
+    "emojiChar": "🗄",
+    "emoji": "\uD83D\uDDC4",
     "description": "file cabinet",
-    "supports_fitzpatrick": false,
     "aliases": [
       "file_cabinet"
     ],
     "tags": []
   },
   {
-    "emoji": "🗑",
+    "emojiChar": "🗑",
+    "emoji": "\uD83D\uDDD1",
     "description": "wastebasket",
-    "supports_fitzpatrick": false,
     "aliases": [
       "wastebasket"
     ],
     "tags": []
   },
   {
-    "emoji": "🗝",
+    "emojiChar": "🗝",
+    "emoji": "\uD83D\uDDDD",
     "description": "an ornate old key",
-    "supports_fitzpatrick": false,
     "aliases": [
       "old_key"
     ],
     "tags": []
   },
   {
-    "emoji": "⛏",
+    "emojiChar": "⛏",
+    "emoji": "\u26CF",
     "description": "pick",
-    "supports_fitzpatrick": false,
     "aliases": [
       "pick"
     ],
     "tags": []
   },
   {
-    "emoji": "⚒",
+    "emojiChar": "⚒",
+    "emoji": "\u2692",
     "description": "hammer and pick",
-    "supports_fitzpatrick": false,
     "aliases": [
       "hammer_and_pick"
     ],
     "tags": []
   },
   {
-    "emoji": "🛠",
+    "emojiChar": "🛠",
+    "emoji": "\uD83D\uDEE0",
     "description": "hammer and wrench",
-    "supports_fitzpatrick": false,
     "aliases": [
       "hammer_and_wrench"
     ],
     "tags": []
   },
   {
-    "emoji": "⚙",
+    "emojiChar": "⚙",
+    "emoji": "\u2699",
     "description": "gear",
-    "supports_fitzpatrick": false,
     "aliases": [
       "gear"
     ],
     "tags": []
   },
   {
-    "emoji": "🗜",
+    "emojiChar": "🗜",
+    "emoji": "\uD83D\uDDDC",
     "description": "compression",
-    "supports_fitzpatrick": false,
     "aliases": [
       "compression"
     ],
     "tags": []
   },
   {
-    "emoji": "⚗",
+    "emojiChar": "⚗",
+    "emoji": "\u2697",
     "description": "alembic",
-    "supports_fitzpatrick": false,
     "aliases": [
       "alembic"
     ],
     "tags": []
   },
   {
-    "emoji": "⚖",
+    "emojiChar": "⚖",
+    "emoji": "\u2696",
     "description": "scales of justice",
-    "supports_fitzpatrick": false,
     "aliases": [
       "scales",
       "scales_of_justice"
@@ -12515,18 +13103,18 @@
     "tags": []
   },
   {
-    "emoji": "⛓",
+    "emojiChar": "⛓",
+    "emoji": "\u26D3",
     "description": "chains",
-    "supports_fitzpatrick": false,
     "aliases": [
       "chains"
     ],
     "tags": []
   },
   {
-    "emoji": "🗡",
+    "emojiChar": "🗡",
+    "emoji": "\uD83D\uDDE1",
     "description": "dagger knife",
-    "supports_fitzpatrick": false,
     "aliases": [
       "dagger",
       "dagger_knife",
@@ -12535,27 +13123,27 @@
     "tags": []
   },
   {
-    "emoji": "⚔",
+    "emojiChar": "⚔",
+    "emoji": "\u2694",
     "description": "crossed swords",
-    "supports_fitzpatrick": false,
     "aliases": [
       "crossed_swords"
     ],
     "tags": []
   },
   {
-    "emoji": "🛡",
+    "emojiChar": "🛡",
+    "emoji": "\uD83D\uDEE1",
     "description": "shield",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shield"
     ],
     "tags": []
   },
   {
-    "emoji": "🏹",
+    "emojiChar": "🏹",
+    "emoji": "\uD83C\uDFF9",
     "description": "bow and arrow",
-    "supports_fitzpatrick": false,
     "aliases": [
       "bow_and_arrow",
       "bow_arrow",
@@ -12564,9 +13152,9 @@
     "tags": []
   },
   {
-    "emoji": "⚰",
+    "emojiChar": "⚰",
+    "emoji": "\u26B0",
     "description": "coffin",
-    "supports_fitzpatrick": false,
     "aliases": [
       "coffin",
       "funeral",
@@ -12575,36 +13163,36 @@
     "tags": []
   },
   {
-    "emoji": "⚱",
+    "emojiChar": "⚱",
+    "emoji": "\u26B1",
     "description": "funeral urn",
-    "supports_fitzpatrick": false,
     "aliases": [
       "funeral_urn"
     ],
     "tags": []
   },
   {
-    "emoji": "🏳",
+    "emojiChar": "🏳",
+    "emoji": "\uD83C\uDFF3",
     "description": "waving white flag",
-    "supports_fitzpatrick": false,
     "aliases": [
       "waving_white_flag"
     ],
     "tags": []
   },
   {
-    "emoji": "🏴",
+    "emojiChar": "🏴",
+    "emoji": "\uD83C\uDFF4",
     "description": "waving black flag",
-    "supports_fitzpatrick": false,
     "aliases": [
       "waving_black_flag"
     ],
     "tags": []
   },
   {
-    "emoji": "⚜",
+    "emojiChar": "⚜",
+    "emoji": "\u269C",
     "description": "fleur-de-lis",
-    "supports_fitzpatrick": false,
     "aliases": [
       "fleur_de_lis",
       "scouts"
@@ -12612,9 +13200,9 @@
     "tags": []
   },
   {
-    "emoji": "⚛",
+    "emojiChar": "⚛",
+    "emoji": "\u269B",
     "description": "atom symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
       "atom",
       "atom_symbol"
@@ -12622,9 +13210,9 @@
     "tags": []
   },
   {
-    "emoji": "🕉",
+    "emojiChar": "🕉",
+    "emoji": "\uD83D\uDD49",
     "description": "om symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
       "om_symbol",
       "pranava",
@@ -12634,36 +13222,36 @@
     "tags": []
   },
   {
-    "emoji": "✡",
+    "emojiChar": "✡",
+    "emoji": "\u2721",
     "description": "star of David",
-    "supports_fitzpatrick": false,
     "aliases": [
       "star_of_david"
     ],
     "tags": []
   },
   {
-    "emoji": "☸",
+    "emojiChar": "☸",
+    "emoji": "\u2638",
     "description": "wheel of Dharma",
-    "supports_fitzpatrick": false,
     "aliases": [
       "wheel_of_dharma"
     ],
     "tags": []
   },
   {
-    "emoji": "☯",
+    "emojiChar": "☯",
+    "emoji": "\u262F",
     "description": "yin yang",
-    "supports_fitzpatrick": false,
     "aliases": [
       "yin_yang"
     ],
     "tags": []
   },
   {
-    "emoji": "✝",
+    "emojiChar": "✝",
+    "emoji": "\u271D",
     "description": "latin cross",
-    "supports_fitzpatrick": false,
     "aliases": [
       "latin_cross",
       "christian_cross"
@@ -12671,18 +13259,18 @@
     "tags": []
   },
   {
-    "emoji": "☦",
+    "emojiChar": "☦",
+    "emoji": "\u2626",
     "description": "orthodox cross",
-    "supports_fitzpatrick": false,
     "aliases": [
       "orthodox_cross"
     ],
     "tags": []
   },
   {
-    "emoji": "⛩",
+    "emojiChar": "⛩",
+    "emoji": "\u26E9",
     "description": "shinto shrine",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shinto_shrine",
       "kami_no_michi"
@@ -12690,9 +13278,9 @@
     "tags": []
   },
   {
-    "emoji": "☪",
+    "emojiChar": "☪",
+    "emoji": "\u262A",
     "description": "star and crescent",
-    "supports_fitzpatrick": false,
     "aliases": [
       "star_and_crescent",
       "star_crescent"
@@ -12700,9 +13288,9 @@
     "tags": []
   },
   {
-    "emoji": "☮",
+    "emojiChar": "☮",
+    "emoji": "\u262E",
     "description": "peace symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
       "peace_symbol",
       "peace_sign"
@@ -12710,9 +13298,9 @@
     "tags": []
   },
   {
-    "emoji": "☢",
+    "emojiChar": "☢",
+    "emoji": "\u2622",
     "description": "radioactive symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
       "radioactive",
       "radioactive_symbol",
@@ -12721,9 +13309,9 @@
     "tags": []
   },
   {
-    "emoji": "☣",
+    "emojiChar": "☣",
+    "emoji": "\u2623",
     "description": "biohazard symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
       "biohazard",
       "biohazard_symbol",
@@ -12732,18 +13320,18 @@
     "tags": []
   },
   {
-    "emoji": "🗨",
+    "emojiChar": "🗨",
+    "emoji": "\uD83D\uDDE8",
     "description": "left speech bubble",
-    "supports_fitzpatrick": false,
     "aliases": [
       "left_speech_bubble"
     ],
     "tags": []
   },
   {
-    "emoji": "👁‍🗨",
+    "emojiChar": "👁‍🗨",
+    "emoji": "\uD83D\uDC41\u200D\uD83D\uDDE8",
     "description": "eye in speech bubble",
-    "supports_fitzpatrick": false,
     "aliases": [
       "eye_in_speech_bubble",
       "i_am_a_witness"
@@ -12751,9 +13339,9 @@
     "tags": []
   },
   {
-    "emoji": "🤣",
+    "emojiChar": "🤣",
+    "emoji": "\uD83E\uDD23",
     "description": "rolling on the floor laughing",
-    "supports_fitzpatrick": false,
     "aliases": [
       "rolling_on_the_floor_laughing",
       "rofl"
@@ -12761,9 +13349,9 @@
     "tags": []
   },
   {
-    "emoji": "🤠",
+    "emojiChar": "🤠",
+    "emoji": "\uD83E\uDD20",
     "description": "face with cowboy hat",
-    "supports_fitzpatrick": false,
     "aliases": [
       "face_with_cowboy_hat",
       "cowboy"
@@ -12771,9 +13359,9 @@
     "tags": []
   },
   {
-    "emoji": "🤡",
+    "emojiChar": "🤡",
+    "emoji": "\uD83E\uDD21",
     "description": "clown face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "clown_face",
       "clown"
@@ -12781,43 +13369,44 @@
     "tags": []
   },
   {
-    "emoji": "🤥",
+    "emojiChar": "🤥",
+    "emoji": "\uD83E\uDD25",
     "description": "lying face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lying_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🤤",
+    "emojiChar": "🤤",
+    "emoji": "\uD83E\uDD24",
     "description": "drooling face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "drooling_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🤢",
+    "emojiChar": "🤢",
+    "emoji": "\uD83E\uDD22",
     "description": "nauseated face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "nauseated_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🤧",
+    "emojiChar": "🤧",
+    "emoji": "\uD83E\uDD27",
     "description": "sneezing face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "sneezing_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🤴",
+    "emojiChar": "🤴",
+    "emoji": "\uD83E\uDD34",
     "description": "prince",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12826,7 +13415,8 @@
     "tags": []
   },
   {
-    "emoji": "🤶",
+    "emojiChar": "🤶",
+    "emoji": "\uD83E\uDD36",
     "description": "mother christmas",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12835,7 +13425,8 @@
     "tags": []
   },
   {
-    "emoji": "🤵",
+    "emojiChar": "🤵",
+    "emoji": "\uD83E\uDD35",
     "description": "man in tuxedo",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12844,7 +13435,8 @@
     "tags": []
   },
   {
-    "emoji": "🤷",
+    "emojiChar": "🤷",
+    "emoji": "\uD83E\uDD37",
     "description": "shrug",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12853,7 +13445,8 @@
     "tags": []
   },
   {
-    "emoji": "🤦",
+    "emojiChar": "🤦",
+    "emoji": "\uD83E\uDD26",
     "description": "face palm",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12862,7 +13455,8 @@
     "tags": []
   },
   {
-    "emoji": "🤰",
+    "emojiChar": "🤰",
+    "emoji": "\uD83E\uDD30",
     "description": "pregnant woman",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12871,7 +13465,8 @@
     "tags": []
   },
   {
-    "emoji": "🕺",
+    "emojiChar": "🕺",
+    "emoji": "\uD83D\uDD7A",
     "description": "man dancing",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12880,7 +13475,8 @@
     "tags": []
   },
   {
-    "emoji": "🤳",
+    "emojiChar": "🤳",
+    "emoji": "\uD83E\uDD33",
     "description": "selfie",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12889,7 +13485,8 @@
     "tags": []
   },
   {
-    "emoji": "🤞",
+    "emojiChar": "🤞",
+    "emoji": "\uD83E\uDD1E",
     "description": "hand with index and middle fingers crossed",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12898,7 +13495,8 @@
     "tags": []
   },
   {
-    "emoji": "🤙",
+    "emojiChar": "🤙",
+    "emoji": "\uD83E\uDD19",
     "description": "call me hand",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12907,7 +13505,8 @@
     "tags": []
   },
   {
-    "emoji": "🤛",
+    "emojiChar": "🤛",
+    "emoji": "\uD83E\uDD1B",
     "description": "left-facing fist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12916,7 +13515,8 @@
     "tags": []
   },
   {
-    "emoji": "🤜",
+    "emojiChar": "🤜",
+    "emoji": "\uD83E\uDD1C",
     "description": "right-facing fist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12925,7 +13525,8 @@
     "tags": []
   },
   {
-    "emoji": "🤚",
+    "emojiChar": "🤚",
+    "emoji": "\uD83E\uDD1A",
     "description": "raised back of hand",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12934,7 +13535,8 @@
     "tags": []
   },
   {
-    "emoji": "🤝",
+    "emojiChar": "🤝",
+    "emoji": "\uD83E\uDD1D",
     "description": "handshake",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -12943,306 +13545,306 @@
     "tags": []
   },
   {
-    "emoji": "🖤",
+    "emojiChar": "🖤",
+    "emoji": "\uD83D\uDDA4",
     "description": "black heart",
-    "supports_fitzpatrick": false,
     "aliases": [
       "black_heart"
     ],
     "tags": []
   },
   {
-    "emoji": "🦍",
+    "emojiChar": "🦍",
+    "emoji": "\uD83E\uDD8D",
     "description": "gorilla",
-    "supports_fitzpatrick": false,
     "aliases": [
       "gorilla"
     ],
     "tags": []
   },
   {
-    "emoji": "🦊",
+    "emojiChar": "🦊",
+    "emoji": "\uD83E\uDD8A",
     "description": "fox face",
-    "supports_fitzpatrick": false,
     "aliases": [
       "fox_face"
     ],
     "tags": []
   },
   {
-    "emoji": "🦌",
+    "emojiChar": "🦌",
+    "emoji": "\uD83E\uDD8C",
     "description": "deer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "deer"
     ],
     "tags": []
   },
   {
-    "emoji": "🦏",
+    "emojiChar": "🦏",
+    "emoji": "\uD83E\uDD8F",
     "description": "rhinoceros",
-    "supports_fitzpatrick": false,
     "aliases": [
       "rhinoceros"
     ],
     "tags": []
   },
   {
-    "emoji": "🦇",
+    "emojiChar": "🦇",
+    "emoji": "\uD83E\uDD87",
     "description": "bat",
-    "supports_fitzpatrick": false,
     "aliases": [
       "bat"
     ],
     "tags": []
   },
   {
-    "emoji": "🦅",
+    "emojiChar": "🦅",
+    "emoji": "\uD83E\uDD85",
     "description": "eagle",
-    "supports_fitzpatrick": false,
     "aliases": [
       "eagle"
     ],
     "tags": []
   },
   {
-    "emoji": "🦆",
+    "emojiChar": "🦆",
+    "emoji": "\uD83E\uDD86",
     "description": "duck",
-    "supports_fitzpatrick": false,
     "aliases": [
       "duck"
     ],
     "tags": []
   },
   {
-    "emoji": "🦉",
+    "emojiChar": "🦉",
+    "emoji": "\uD83E\uDD89",
     "description": "owl",
-    "supports_fitzpatrick": false,
     "aliases": [
       "owl"
     ],
     "tags": []
   },
   {
-    "emoji": "🦎",
+    "emojiChar": "🦎",
+    "emoji": "\uD83E\uDD8E",
     "description": "lizard",
-    "supports_fitzpatrick": false,
     "aliases": [
       "lizard"
     ],
     "tags": []
   },
   {
-    "emoji": "🦈",
+    "emojiChar": "🦈",
+    "emoji": "\uD83E\uDD88",
     "description": "shark",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shark"
     ],
     "tags": []
   },
   {
-    "emoji": "🦐",
+    "emojiChar": "🦐",
+    "emoji": "\uD83E\uDD90",
     "description": "shrimp",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shrimp"
     ],
     "tags": []
   },
   {
-    "emoji": "🦑",
+    "emojiChar": "🦑",
+    "emoji": "\uD83E\uDD91",
     "description": "squid",
-    "supports_fitzpatrick": false,
     "aliases": [
       "squid"
     ],
     "tags": []
   },
   {
-    "emoji": "🦋",
+    "emojiChar": "🦋",
+    "emoji": "\uD83E\uDD8B",
     "description": "butterfly",
-    "supports_fitzpatrick": false,
     "aliases": [
       "butterfly"
     ],
     "tags": []
   },
   {
-    "emoji": "🥀",
+    "emojiChar": "🥀",
+    "emoji": "\uD83E\uDD40",
     "description": "wilted flower",
-    "supports_fitzpatrick": false,
     "aliases": [
       "wilted_flower"
     ],
     "tags": []
   },
   {
-    "emoji": "🥝",
+    "emojiChar": "🥝",
+    "emoji": "\uD83E\uDD5D",
     "description": "kiwifruit",
-    "supports_fitzpatrick": false,
     "aliases": [
       "kiwifruit"
     ],
     "tags": []
   },
   {
-    "emoji": "🥑",
+    "emojiChar": "🥑",
+    "emoji": "\uD83E\uDD51",
     "description": "avocado",
-    "supports_fitzpatrick": false,
     "aliases": [
       "avocado"
     ],
     "tags": []
   },
   {
-    "emoji": "🥔",
+    "emojiChar": "🥔",
+    "emoji": "\uD83E\uDD54",
     "description": "potato",
-    "supports_fitzpatrick": false,
     "aliases": [
       "potato"
     ],
     "tags": []
   },
   {
-    "emoji": "🥕",
+    "emojiChar": "🥕",
+    "emoji": "\uD83E\uDD55",
     "description": "carrot",
-    "supports_fitzpatrick": false,
     "aliases": [
       "carrot"
     ],
     "tags": []
   },
   {
-    "emoji": "🥒",
+    "emojiChar": "🥒",
+    "emoji": "\uD83E\uDD52",
     "description": "cucumber",
-    "supports_fitzpatrick": false,
     "aliases": [
       "cucumber"
     ],
     "tags": []
   },
   {
-    "emoji": "🥜",
+    "emojiChar": "🥜",
+    "emoji": "\uD83E\uDD5C",
     "description": "peanuts",
-    "supports_fitzpatrick": false,
     "aliases": [
       "peanuts"
     ],
     "tags": []
   },
   {
-    "emoji": "🥐",
+    "emojiChar": "🥐",
+    "emoji": "\uD83E\uDD50",
     "description": "croissant",
-    "supports_fitzpatrick": false,
     "aliases": [
       "croissant"
     ],
     "tags": []
   },
   {
-    "emoji": "🥖",
+    "emojiChar": "🥖",
+    "emoji": "\uD83E\uDD56",
     "description": "baguette bread",
-    "supports_fitzpatrick": false,
     "aliases": [
       "baguette_bread"
     ],
     "tags": []
   },
   {
-    "emoji": "🥞",
+    "emojiChar": "🥞",
+    "emoji": "\uD83E\uDD5E",
     "description": "pancakes",
-    "supports_fitzpatrick": false,
     "aliases": [
       "pancakes"
     ],
     "tags": []
   },
   {
-    "emoji": "🥓",
+    "emojiChar": "🥓",
+    "emoji": "\uD83E\uDD53",
     "description": "bacon",
-    "supports_fitzpatrick": false,
     "aliases": [
       "bacon"
     ],
     "tags": []
   },
   {
-    "emoji": "🥙",
+    "emojiChar": "🥙",
+    "emoji": "\uD83E\uDD59",
     "description": "stuffed flatbread",
-    "supports_fitzpatrick": false,
     "aliases": [
       "stuffed_flatbread"
     ],
     "tags": []
   },
   {
-    "emoji": "🥚",
+    "emojiChar": "🥚",
+    "emoji": "\uD83E\uDD5A",
     "description": "egg",
-    "supports_fitzpatrick": false,
     "aliases": [
       "egg"
     ],
     "tags": []
   },
   {
-    "emoji": "🥘",
+    "emojiChar": "🥘",
+    "emoji": "\uD83E\uDD58",
     "description": "shallow pan of food",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shallow_pan_of_food"
     ],
     "tags": []
   },
   {
-    "emoji": "🥗",
+    "emojiChar": "🥗",
+    "emoji": "\uD83E\uDD57",
     "description": "green salad",
-    "supports_fitzpatrick": false,
     "aliases": [
       "green_salad"
     ],
     "tags": []
   },
   {
-    "emoji": "🥛",
+    "emojiChar": "🥛",
+    "emoji": "\uD83E\uDD5B",
     "description": "glass of milk",
-    "supports_fitzpatrick": false,
     "aliases": [
       "glass_of_milk"
     ],
     "tags": []
   },
   {
-    "emoji": "🥂",
+    "emojiChar": "🥂",
+    "emoji": "\uD83E\uDD42",
     "description": "clinking glasses",
-    "supports_fitzpatrick": false,
     "aliases": [
       "clinking_glasses"
     ],
     "tags": []
   },
   {
-    "emoji": "🥃",
+    "emojiChar": "🥃",
+    "emoji": "\uD83E\uDD43",
     "description": "tumbler glass",
-    "supports_fitzpatrick": false,
     "aliases": [
       "tumbler_glass"
     ],
     "tags": []
   },
   {
-    "emoji": "🥄",
+    "emojiChar": "🥄",
+    "emoji": "\uD83E\uDD44",
     "description": "spoon",
-    "supports_fitzpatrick": false,
     "aliases": [
       "spoon"
     ],
     "tags": []
   },
   {
-    "emoji": "🛑",
+    "emojiChar": "🛑",
+    "emoji": "\uD83D\uDED1",
     "description": "octagonal sign",
-    "supports_fitzpatrick": false,
     "aliases": [
       "octagonal_sign",
       "stop_sign"
@@ -13250,79 +13852,80 @@
     "tags": []
   },
   {
-    "emoji": "🛴",
+    "emojiChar": "🛴",
+    "emoji": "\uD83D\uDEF4",
     "description": "scooter",
-    "supports_fitzpatrick": false,
     "aliases": [
       "scooter"
     ],
     "tags": []
   },
   {
-    "emoji": "🛵",
+    "emojiChar": "🛵",
+    "emoji": "\uD83D\uDEF5",
     "description": "motor scooter",
-    "supports_fitzpatrick": false,
     "aliases": [
       "motor_scooter"
     ],
     "tags": []
   },
   {
-    "emoji": "🛶",
+    "emojiChar": "🛶",
+    "emoji": "\uD83D\uDEF6",
     "description": "canoe",
-    "supports_fitzpatrick": false,
     "aliases": [
       "canoe"
     ],
     "tags": []
   },
   {
-    "emoji": "🥇",
+    "emojiChar": "🥇",
+    "emoji": "\uD83E\uDD47",
     "description": "first place medal",
-    "supports_fitzpatrick": false,
     "aliases": [
       "first_place_medal"
     ],
     "tags": []
   },
   {
-    "emoji": "🥈",
+    "emojiChar": "🥈",
+    "emoji": "\uD83E\uDD48",
     "description": "second place medal",
-    "supports_fitzpatrick": false,
     "aliases": [
       "second_place_medal"
     ],
     "tags": []
   },
   {
-    "emoji": "🥉",
+    "emojiChar": "🥉",
+    "emoji": "\uD83E\uDD49",
     "description": "third place medal",
-    "supports_fitzpatrick": false,
     "aliases": [
       "third_place_medal"
     ],
     "tags": []
   },
   {
-    "emoji": "🥊",
+    "emojiChar": "🥊",
+    "emoji": "\uD83E\uDD4A",
     "description": "boxing glove",
-    "supports_fitzpatrick": false,
     "aliases": [
       "boxing_glove"
     ],
     "tags": []
   },
   {
-    "emoji": "🥋",
+    "emojiChar": "🥋",
+    "emoji": "\uD83E\uDD4B",
     "description": "martial arts uniform",
-    "supports_fitzpatrick": false,
     "aliases": [
       "martial_arts_uniform"
     ],
     "tags": []
   },
   {
-    "emoji": "🤸",
+    "emojiChar": "🤸",
+    "emoji": "\uD83E\uDD38",
     "description": "person doing cartwheel",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13331,7 +13934,8 @@
     "tags": []
   },
   {
-    "emoji": "🤸‍♂️",
+    "emojiChar": "🤸‍♂️",
+    "emoji": "\uD83E\uDD38\u200D\u2642\uFE0F",
     "description": "man doing cartwheel",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13341,7 +13945,8 @@
     "tags": []
   },
   {
-    "emoji": "🤸‍♀️",
+    "emojiChar": "🤸‍♀️",
+    "emoji": "\uD83E\uDD38\u200D\u2640\uFE0F",
     "description": "woman doing cartwheel",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13351,7 +13956,8 @@
     "tags": []
   },
   {
-    "emoji": "🤼",
+    "emojiChar": "🤼",
+    "emoji": "\uD83E\uDD3C",
     "description": "wrestlers",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13360,7 +13966,8 @@
     "tags": []
   },
   {
-    "emoji": "🤼‍♂️",
+    "emojiChar": "🤼‍♂️",
+    "emoji": "\uD83E\uDD3C\u200D\u2642\uFE0F",
     "description": "man wrestlers",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13370,7 +13977,8 @@
     "tags": []
   },
   {
-    "emoji": "🤼‍♀️",
+    "emojiChar": "🤼‍♀️",
+    "emoji": "\uD83E\uDD3C\u200D\u2640\uFE0F",
     "description": "woman wrestlers",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13380,7 +13988,8 @@
     "tags": []
   },
   {
-    "emoji": "🤽",
+    "emojiChar": "🤽",
+    "emoji": "\uD83E\uDD3D",
     "description": "water polo",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13389,7 +13998,8 @@
     "tags": []
   },
   {
-    "emoji": "🤽‍♂️",
+    "emojiChar": "🤽‍♂️",
+    "emoji": "\uD83E\uDD3D\u200D\u2642\uFE0F",
     "description": "man water polo",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13399,7 +14009,8 @@
     "tags": []
   },
   {
-    "emoji": "🤽‍♀️",
+    "emojiChar": "🤽‍♀️",
+    "emoji": "\uD83E\uDD3D\u200D\u2640\uFE0F",
     "description": "woman water polo",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13409,7 +14020,8 @@
     "tags": []
   },
   {
-    "emoji": "🤾",
+    "emojiChar": "🤾",
+    "emoji": "\uD83E\uDD3E",
     "description": "handball",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13418,7 +14030,8 @@
     "tags": []
   },
   {
-    "emoji": "🤾‍♂️",
+    "emojiChar": "🤾‍♂️",
+    "emoji": "\uD83E\uDD3E\u200D\u2642\uFE0F",
     "description": "man handball",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13428,7 +14041,8 @@
     "tags": []
   },
   {
-    "emoji": "🤾‍♀️",
+    "emojiChar": "🤾‍♀️",
+    "emoji": "\uD83E\uDD3E\u200D\u2640\uFE0F",
     "description": "woman handball",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13438,25 +14052,26 @@
     "tags": []
   },
   {
-    "emoji": "🤺",
+    "emojiChar": "🤺",
+    "emoji": "\uD83E\uDD3A",
     "description": "fencer",
-    "supports_fitzpatrick": false,
     "aliases": [
       "fencer"
     ],
     "tags": []
   },
   {
-    "emoji": "🥅",
+    "emojiChar": "🥅",
+    "emoji": "\uD83E\uDD45",
     "description": "goal net",
-    "supports_fitzpatrick": false,
     "aliases": [
       "goal_net"
     ],
     "tags": []
   },
   {
-    "emoji": "🤹",
+    "emojiChar": "🤹",
+    "emoji": "\uD83E\uDD39",
     "description": "juggling",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13465,7 +14080,8 @@
     "tags": []
   },
   {
-    "emoji": "🤹‍♂️",
+    "emojiChar": "🤹‍♂️",
+    "emoji": "\uD83E\uDD39\u200D\u2642\uFE0F",
     "description": "man juggling",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13475,7 +14091,8 @@
     "tags": []
   },
   {
-    "emoji": "🤹‍♀️",
+    "emojiChar": "🤹‍♀️",
+    "emoji": "\uD83E\uDD39\u200D\u2640\uFE0F",
     "description": "woman juggling",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13485,18 +14102,18 @@
     "tags": []
   },
   {
-    "emoji": "🥁",
+    "emojiChar": "🥁",
+    "emoji": "\uD83E\uDD41",
     "description": "drum with drumsticks",
-    "supports_fitzpatrick": false,
     "aliases": [
       "drum_with_drumsticks"
     ],
     "tags": []
   },
   {
-    "emoji": "🛒",
+    "emojiChar": "🛒",
+    "emoji": "\uD83D\uDED2",
     "description": "shopping trolley",
-    "supports_fitzpatrick": false,
     "aliases": [
       "shopping_trolley",
       "shopping_cart"
@@ -13504,7 +14121,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍⚕️",
+    "emojiChar": "👨‍⚕️",
+    "emoji": "\uD83D\uDC68\u200D\u2695\uFE0F",
     "description": "man health worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13514,7 +14132,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍⚕️",
+    "emojiChar": "👩‍⚕️",
+    "emoji": "\uD83D\uDC69\u200D\u2695\uFE0F",
     "description": "woman health worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13524,7 +14143,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🎓",
+    "emojiChar": "👨‍🎓",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDF93",
     "description": "man student",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13534,7 +14154,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🎓",
+    "emojiChar": "👩‍🎓",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDF93",
     "description": "woman student",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13544,7 +14165,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🏫",
+    "emojiChar": "👨‍🏫",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDFEB",
     "description": "man teacher",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13554,7 +14176,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🏫",
+    "emojiChar": "👩‍🏫",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDFEB",
     "description": "woman teacher",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13564,7 +14187,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🌾",
+    "emojiChar": "👨‍🌾",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDF3E",
     "description": "man farmer",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13574,7 +14198,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🌾",
+    "emojiChar": "👩‍🌾",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDF3E",
     "description": "woman famer",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13584,7 +14209,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🍳",
+    "emojiChar": "👨‍🍳",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDF73",
     "description": "man cook",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13594,7 +14220,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🍳",
+    "emojiChar": "👩‍🍳",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDF73",
     "description": "woman cook",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13604,7 +14231,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🔧",
+    "emojiChar": "👨‍🔧",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDD27",
     "description": "man mechanic",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13614,7 +14242,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🔧",
+    "emojiChar": "👩‍🔧",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDD27",
     "description": "woman mechanic",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13624,7 +14253,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🏭",
+    "emojiChar": "👨‍🏭",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDFED",
     "description": "man factory worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13634,7 +14264,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🏭",
+    "emojiChar": "👩‍🏭",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDFED",
     "description": "woman factory worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13644,7 +14275,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍💼",
+    "emojiChar": "👨‍💼",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDCBC",
     "description": "man office worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13654,7 +14286,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍💼",
+    "emojiChar": "👩‍💼",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDCBC",
     "description": "woman office worker",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13664,7 +14297,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🔬",
+    "emojiChar": "👨‍🔬",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDD2C",
     "description": "man scientist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13674,7 +14308,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🔬",
+    "emojiChar": "👩‍🔬",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDD2C",
     "description": "woman scientist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13684,7 +14319,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍💻",
+    "emojiChar": "👨‍💻",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDCBB",
     "description": "man technologist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13694,7 +14330,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍💻",
+    "emojiChar": "👩‍💻",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDCBB",
     "description": "woman technologist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13704,7 +14341,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🎤",
+    "emojiChar": "👨‍🎤",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDFA4",
     "description": "man singer",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13714,7 +14352,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🎤",
+    "emojiChar": "👩‍🎤",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDFA4",
     "description": "woman singer",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13724,7 +14363,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🎨",
+    "emojiChar": "👨‍🎨",
+    "emoji": "\uD83D\uDC68\u200D\uD83C\uDFA8",
     "description": "man artist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13734,7 +14374,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🎨",
+    "emojiChar": "👩‍🎨",
+    "emoji": "\uD83D\uDC69\u200D\uD83C\uDFA8",
     "description": "woman artist",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13744,7 +14385,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍✈️",
+    "emojiChar": "👨‍✈️",
+    "emoji": "\uD83D\uDC68\u200D\u2708\uFE0F",
     "description": "man pilot",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13754,7 +14396,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍✈️",
+    "emojiChar": "👩‍✈️",
+    "emoji": "\uD83D\uDC69\u200D\u2708\uFE0F",
     "description": "woman pilot",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13764,7 +14407,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🚀",
+    "emojiChar": "👨‍🚀",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDE80",
     "description": "man astronaut",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13774,7 +14418,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🚀",
+    "emojiChar": "👩‍🚀",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDE80",
     "description": "woman astronaut",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13784,7 +14429,8 @@
     "tags": []
   },
   {
-    "emoji": "👨‍🚒",
+    "emojiChar": "👨‍🚒",
+    "emoji": "\uD83D\uDC68\u200D\uD83D\uDE92",
     "description": "man firefighter",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13794,7 +14440,8 @@
     "tags": []
   },
   {
-    "emoji": "👩‍🚒",
+    "emojiChar": "👩‍🚒",
+    "emoji": "\uD83D\uDC69\u200D\uD83D\uDE92",
     "description": "woman firefighter",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13804,7 +14451,8 @@
     "tags": []
   },
   {
-    "emoji": "🤦‍♀️",
+    "emojiChar": "🤦‍♀️",
+    "emoji": "\uD83E\uDD26\u200D\u2640\uFE0F",
     "description": "woman facepalm",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13814,7 +14462,8 @@
     "tags": []
   },
   {
-    "emoji": "🤷‍♂️",
+    "emojiChar": "🤷‍♂️",
+    "emoji": "\uD83E\uDD37\u200D\u2642\uFE0F",
     "description": "man shrug",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13824,7 +14473,8 @@
     "tags": []
   },
   {
-    "emoji": "🤷‍♀️",
+    "emojiChar": "🤷‍♀️",
+    "emoji": "\uD83E\uDD37\u200D\u2640\uFE0F",
     "description": "woman shrug",
     "supports_fitzpatrick": true,
     "aliases": [
@@ -13834,9 +14484,9 @@
     "tags": []
   },
   {
-    "emoji": "⚕",
+    "emojiChar": "⚕",
+    "emoji": "\u2695",
     "description": "medical symbol",
-    "supports_fitzpatrick": false,
     "aliases": [
       "medical_symbol",
       "staff_of_aesculapius"
@@ -13844,9 +14494,9 @@
     "tags": []
   },
   {
-    "emoji": "👨‍⚖️",
+    "emojiChar": "👨‍⚖️",
+    "emoji": "\uD83D\uDC68\u200D\u2696\uFE0F",
     "description": "man judge",
-    "supports_fitzpatrick": false,
     "aliases": [
       "man_judge",
       "male_judge"
@@ -13854,9 +14504,9 @@
     "tags": []
   },
   {
-    "emoji": "👩‍⚖️",
+    "emojiChar": "👩‍⚖️",
+    "emoji": "\uD83D\uDC69\u200D\u2696\uFE0F",
     "description": "woman judge",
-    "supports_fitzpatrick": false,
     "aliases": [
       "woman_judge",
       "female_judge"


### PR DESCRIPTION
Right now we only had the unicode character in the JSON file but depending on your editor, it's sometimes hard to read the source code. This commit keeps the current emoji in an `emojiChar` property (it helps to find an emoji in the file sometimes!) and adds the "source code" version in the `emoji` property.